### PR TITLE
added test for visibility of dBildungscloud password reset pop-up

### DIFF
--- a/cypress/integration/features/login_management/forgotPasswordDialog.feature
+++ b/cypress/integration/features/login_management/forgotPasswordDialog.feature
@@ -1,0 +1,14 @@
+Feature: Visibility of dBildungscloud Password Reset dialog
+
+  As a user (teacher or student or admin), I want to see password recovery dialog visible to me so that I can recover my password in case needed.
+
+  Scenario: User sees password recovery dialog
+    Given I am on the dBildungscloud login page as a user on BRB
+    When I click on Forgot Password? link
+    Then I see the Reset Password dialog with username label, email input box, info message, cancel and send reset password buttons
+
+  Scenario: Entering email or user name is mandatory
+    Given I am on the dBildungscloud login page as a user on BRB
+    When I click on Forgot Password? link
+    When I remove my email from the input box and submit the request
+    Then I still see the email input box that request is not submitted

--- a/cypress/support/pages/login_management/pageLoginManagement.js
+++ b/cypress/support/pages/login_management/pageLoginManagement.js
@@ -1,0 +1,37 @@
+'use strict'
+
+class Login_Management {
+
+  static #passwordRecoveryButton = '[data-testid="forgot-password"]'
+  static #usernameLabel = '[data-testid="username-label"]'
+  static #emailInputBox = '[id="username"]'
+  static #infoMessage = '[data-testid="info-message"]'
+  static #submitButton = '[data-testid="btn-submit"]'
+  static #cancelButton = '[data-testid="btn-cancel"]'
+
+  beingOnLoginPage() {
+    cy.visit(Cypress.env('BRB'))
+  }
+
+  clickOnForgotPassword() {
+    cy.get(Login_Management.#passwordRecoveryButton).eq(1).click()
+  }
+
+  showElementOnDialog() {
+    cy.get(Login_Management.#usernameLabel).should('be.visible')
+    cy.get(Login_Management.#emailInputBox).should('be.visible')
+    cy.get(Login_Management.#infoMessage).should('be.visible')
+    cy.get(Login_Management.#submitButton).should('be.visible')
+    cy.get(Login_Management.#cancelButton).should('be.visible')
+  }
+
+  submitRequestWithoutEmail() {
+    cy.get(Login_Management.#emailInputBox).type('email@example.com').clear()
+    cy.get(Login_Management.#submitButton).click()
+  }
+
+  seeEmailInputOnSubmitingRequestWithoutEnteringEmail() {
+    cy.get(Login_Management.#emailInputBox).should('be.visible')
+  }
+}
+export default Login_Management

--- a/cypress/support/step_definition/login_management/commonLoginManagementRelatedSteps.spec.js
+++ b/cypress/support/step_definition/login_management/commonLoginManagementRelatedSteps.spec.js
@@ -1,0 +1,11 @@
+import Login_Management from '../../pages/login_management/pageLoginManagement'
+
+const loginManagement = new Login_Management()
+
+Given('I am on the dBildungscloud login page as a user on BRB', () => {
+    loginManagement.beingOnLoginPage()
+})
+
+When('I click on Forgot Password? link', () => {
+    loginManagement.clickOnForgotPassword()
+})

--- a/cypress/support/step_definition/login_management/forgotPasswordDialogSteps.spec.js
+++ b/cypress/support/step_definition/login_management/forgotPasswordDialogSteps.spec.js
@@ -1,0 +1,29 @@
+import Login_Management from '../../pages/login_management/pageLoginManagement'
+
+const loginManagement = new Login_Management()
+
+//Scenario: User sees password recovery dialog
+//Given I am on the dBildungscloud login page as a user on BRB
+//this step defined in --> \step_definition\login_management\commonLoginManagementRelatedSteps.spec.js
+
+//When I click on Forgot Password? link
+//this step defined in --> \step_definition\login_management\commonLoginManagementRelatedSteps.spec.js
+
+Then('I see the Reset Password dialog with username label, email input box, info message, cancel and send reset password buttons', () => {
+  loginManagement.showElementOnDialog()
+})
+
+//Scenario: Entering email or user name is mandatory
+// Given I am on the dBildungscloud login page as a user on BRB
+//this step defined in --> \step_definition\login_management\commonLoginManagementRelatedSteps.spec.js
+
+//When I click on Forgot Password? link
+//this step defined in  --> \step_definition\login_management\commonLoginManagementRelatedSteps.spec.js
+
+When('I remove my email from the input box and submit the request', () => {
+  loginManagement.submitRequestWithoutEmail()
+})
+
+Then('I still see the email input box that request is not submitted', () => {
+  loginManagement.seeEmailInputOnSubmitingRequestWithoutEnteringEmail()
+})


### PR DESCRIPTION
## Links to Tickets or other pull requests
https://ticketsystem.dbildungscloud.de/browse/BC-1830

## Changes
- Added tests for password recovery dialog box element visibility.
- Commented out rest of the for better readability for the test in scope in this PR /ticket.

