### PR TITLE
select lang DE after each login

### DIFF
--- a/cypress/support/custom_commands/login.js
+++ b/cypress/support/custom_commands/login.js
@@ -2,6 +2,9 @@ const emailInputFieldElement = '[data-testid="username-email"]'
 const passwordInputFieldElement = '[data-testid="password-email"]'
 const submitButton = '[data-testid="submit-login-email"]'
 const nbcLoginWithEmailOptionButton = '[data-testid="submit-cloud-site"]'
+const initials = '[data-testid="initials"]'
+const languageSelection = '[id="selected-language"]'
+const languageDe = '[data-language="de"]'
 
 Cypress.Commands.add('login', (username, environment) => {
   cy.session([username, environment], () => {
@@ -69,6 +72,10 @@ Cypress.Commands.add('login', (username, environment) => {
     cy.get(passwordInputFieldElement).eq(1).type(env[userPassword], {log:false})
     cy.get(submitButton).eq(1).click()
     cy.url().should('contain', '/dashboard')
+    cy.get(initials).click()
+    cy.get(languageSelection).click()
+    cy.get(languageDe).click()
+
   })
   cy.visit('/dashboard')
 })

--- a/cypress/support/pages/tasks/pageTasks.js
+++ b/cypress/support/pages/tasks/pageTasks.js
@@ -2,6 +2,7 @@
 
 class Tasks {
   static #pageTitle = '[id="page-title"]'
+  static #localeDateFormat = 'de-DE'
   static #createForm = '[id="homework-form"]'
   static #taskNameInput = '[data-testid="homework-name"]'
   static #groupSubmissionCheckbox = '[id="teamSubmissions"]'
@@ -78,9 +79,8 @@ class Tasks {
       startDate = new Date(today)
       startDate.setDate(startDate.getDate() + 1)
     }
-    let startDateText = startDate.toLocaleString('en-GB', {year:'numeric', day: '2-digit', month: '2-digit'})
-    startDateText = startDateText.replace('/', '')
-    cy.get(Tasks.#visibilityStartDateInput).type(`{moveToStart}${startDateText}${visibilityStartTime}`)
+    let startDateText = startDate.toLocaleString(Tasks.#localeDateFormat, {year:'numeric', day: '2-digit', month: '2-digit'})
+    cy.get(Tasks.#visibilityStartDateInput).type(`{selectAll}${startDateText}${visibilityStartTime}`)
   }
 
   setVisibilityDueDate(visibilityDueDate, visibilityDueTime) {
@@ -92,9 +92,8 @@ class Tasks {
       dueDate = new Date(today)
       dueDate.setDate(dueDate.getDate() + 1)
     }
-    let startDueText = dueDate.toLocaleString('en-GB', {year:'numeric', day: '2-digit', month: '2-digit'})
-    startDueText = startDueText.replace('/', '')
-    cy.get(Tasks.#visibilityDueDateInput).type(`{moveToStart}${startDueText}${visibilityDueTime}`)
+    let startDueText = dueDate.toLocaleString(Tasks.#localeDateFormat, {year:'numeric', day: '2-digit', month: '2-digit'})
+    cy.get(Tasks.#visibilityDueDateInput).type(`{selectAll}${startDueText}${visibilityDueTime}`)
   }
 
   setTaskText(taskText){


### PR DESCRIPTION
# Description

Problem was the date format that depends on the user language. As there are different cases in which different user language could cause issues, we decided to set the language after each login to german (de).
Also improved the date input in tasks.

## Links to Tickets or other pull requests

Base links to copy
- https://ticketsystem.dbildungscloud.de/browse/BC-????](https://ticketsystem.dbildungscloud.de/browse/BC-2359)

## Changes

  Set user language to German (de) after each login
  use selectAll before typing the date (in editing / creating Tasks) to overwrite the content of the field
  use const with language to set date format (in editing / creating Tasks)


## Datasecurity

<!--
  Notice about:
  - model changes
  - logging of user data
  - right changes
  - and other user data stuff
  If you are not sure if it is relevant, take a look at confluence or ask the data-security team.
-->

## Deployment

<!--
  Keep in mind to changes to seed data, if changes are done by migration scripts.
  Changes to the infrastructure have to discussed with the devops

  This point should includes following informations:
  - What is required for deployment?
  - Envirement variables like FEATURE_XY=true
  - Migration scripts to run, other requirements
-->

## New Repos, NPM pakages or vendor scripts

<!--
  Keep in mind the stability, performance, activity and author.

  Describe why it is needed.
-->

## Screenshots of UI changes

<!--
  only needed for visual changes

  If visual changes exist, work together with UI/UX from beginning/ping UX with final PR
-->

## Approval for review

- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.
