### PR TITLE
BC-1875 - bug fixed - add students and teachers separated

### DIFF
--- a/cypress/integration/features/management/admin_management/administrateUsers.feature
+++ b/cypress/integration/features/management/admin_management/administrateUsers.feature
@@ -6,7 +6,8 @@ Feature: Admin Users - To add, edit and delete new users by the admin.
     Given I am logged in as a 'admin' at 'brb'
     When I go to administration page
     And I go to student administration
-    And I click on FAB to add a user
+    When I click on FAB
+    When I click on Add Student in opened FAB
     And I fill out the user creation form for 'Adam' 'Riese' with email 'adam.riese@example.com'
     And I click on add button to add 'student'
     Then I can see the user with email 'adam.riese@example.com' in the table
@@ -37,7 +38,8 @@ Feature: Admin Users - To add, edit and delete new users by the admin.
     Given I am logged in as a 'admin' at 'brb'
     When I go to administration page
     And I go to teacher administration
-    And I click on FAB to add a user
+    When I click on FAB
+    When I click on Add Teacher in opened FAB
     And I fill out the user creation form for 'Karl' 'Müller' with email 'karl.mueller@example.com'
     And I click on add button to add 'teacher'
     Then I can see the user with email 'karl.mueller@example.com' in the table

--- a/cypress/support/pages/management/pageManagement.js
+++ b/cypress/support/pages/management/pageManagement.js
@@ -2,7 +2,8 @@
 
 class Management {
   static #fabButton = '#fab'
-  static #createUserButton = '.v-btn--router'
+  static #addStudentButton = '[data-testid="fab_button_add_students"]'
+  static #addTeacherButton = '[data-testid="fab_button_add_teachers"]'
   static #firstNameCreationForm = '[data-testid="input_create-user_firstname"]'
   static #lastNameCreationForm = '[data-testid="input_create-user_lastname"]'
   static #emailCreationForm = '[data-testid="input_create-user_email"]'
@@ -23,7 +24,14 @@ class Management {
 
   clickOnFAB () {
     cy.get(Management.#fabButton).click()
-    cy.get(Management.#createUserButton).click()
+  }
+
+  clickOnAddStudentInFAB () {
+    cy.get(Management.#addStudentButton).click()
+  }
+
+  clickOnAddTeacherInFAB () {
+    cy.get(Management.#addTeacherButton).click()
   }
 
   fillUserCreationForm (forename, surname, email) {

--- a/cypress/support/step_definition/management/CommonManagementSteps.spec.js
+++ b/cypress/support/step_definition/management/CommonManagementSteps.spec.js
@@ -28,6 +28,14 @@ And('I go to teacher administration', () => {
   managementCommon.navigateToTeacherAdministration()
 })
 
-And('I click on FAB to add a user', () => {
+When('I click on FAB', () => {
   management.clickOnFAB()
+})
+
+When('I click on Add Student in opened FAB', () => {
+  management.clickOnAddStudentInFAB()
+})
+
+When('I click on Add Teacher in opened FAB', () => {
+  management.clickOnAddTeacherInFAB()
 })


### PR DESCRIPTION
# Description

The selector of FAB -> Add user did not work anymore. I separated the handling for teacher and student and used the data-testids.

## Links to Tickets or other pull requests

<!--
Base links to copy
- https://github.com/hpi-schul-cloud/schulcloud-server/pull/????
- https://ticketsystem.dbildungscloud.de/browse/BC-????
-->

## Changes

<!--
  What will the PR change?
  Why are the changes requiered?
  Short notice if a ticket exists, more detailed if not
-->

## Datasecurity

<!--
  Notice about:
  - model changes
  - logging of user data
  - right changes
  - and other user data stuff
  If you are not sure if it is relevant, take a look at confluence or ask the data-security team.
-->

## Deployment

<!--
  Keep in mind to changes to seed data, if changes are done by migration scripts.
  Changes to the infrastructure have to discussed with the devops

  This point should includes following informations:
  - What is required for deployment?
  - Envirement variables like FEATURE_XY=true
  - Migration scripts to run, other requirements
-->

## New Repos, NPM pakages or vendor scripts

<!--
  Keep in mind the stability, performance, activity and author.

  Describe why it is needed.
-->

## Screenshots of UI changes

<!--
  only needed for visual changes

  If visual changes exist, work together with UI/UX from beginning/ping UX with final PR
-->

## Approval for review

- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.
