### PR TITLE
Bc 1875 create delete task from taskpage

### DIFF
--- a/cypress/integration/features/task/createDeleteTaskFromTaskPage.feature
+++ b/cypress/integration/features/task/createDeleteTaskFromTaskPage.feature
@@ -1,0 +1,30 @@
+Feature: Task - To create and delete tasks starting from task overview page by the teacher.
+
+  As a teacher I want to create and delete a new task on the task overview page so that the student can submit it
+
+ Scenario: As a user, I want to be able to create a simple task without course
+   Given I am logged in as a 'teacher1' at 'brb'
+   When I go to tasks overview
+   When I click on button Add Task
+#    Then I am on new task page
+#    When I enter title 'Cy Task Creating from Task Overview Test'
+#    When I enter task description 'This is a task for the students.'
+#    When I click on button Submit
+#    Then I can see create task page 'Cy Task Creating from Task Overview Test'
+#    When I click on button Submit
+#    When I go to tasks page
+#    When I click on draft tab
+#    Then I can see task 'Cy Task Creating from Task Overview Test'
+
+#  Scenario: As a user, I want to be able to delete a simple task without course
+#    Given I am logged in as 'teacher1' at 'brb'
+#    When I go to tasks page
+#    When I click on draft tab
+#    When I click on three dot menu of content 'Cy Task Creating from Task Overview Test'
+#    When I click on Delete in dot menu
+#    When I click on Delete in confirmation window
+#   # new opening of the room page is necessary to clear DOM from deleted tasks (reload would also work but would need a cy.wait)
+#    When I arrive on the dashboard
+#    When I go to tasks page
+#    When I click on draft tab
+#    Then I can not see task 'Cy Task Creating from Task Overview Test'

--- a/cypress/integration/features/task/createDeleteTaskFromTaskPage.feature
+++ b/cypress/integration/features/task/createDeleteTaskFromTaskPage.feature
@@ -32,11 +32,11 @@ Feature: Task - To create and delete tasks starting from task overview page by t
    When I click on draft tasks tab
    When I click on three dot menu of task 'Cy Task Creating from Task Overview Test'
    When I click on Delete Task in dot menu
-    And I click on Cancel in confirmation window
+   When I click on Cancel in confirmation window
    When I click on three dot menu of task 'Cy Task Creating from Task Overview Test'
    When I click on Delete Task in dot menu
    When I click on Delete in confirmation window
-#   # new opening of the room page is necessary to clear DOM from deleted tasks (reload would also work but would need a cy.wait)
+  # new opening of the room page is necessary to clear DOM from deleted tasks (reload would also work but would need a cy.wait)
    When I arrive on the dashboard
    When I go to tasks overview
    When I click on draft tasks tab
@@ -48,13 +48,11 @@ Feature: Task - To create and delete tasks starting from task overview page by t
    When I click on draft tasks tab
    When I click on task 'Cy Task to be delete on task page' in tasks overview
    When I click on button Delete
-    # And I click on Cancel in confirmation window
-#     And I click on Cancel in confirmation window
-#    When I click on three dot menu of task 'Cy Task Creating from Task Overview Test'
-#    When I click on Delete Task in dot menu
-#    When I click on Delete in confirmation window
-# #   # new opening of the room page is necessary to clear DOM from deleted tasks (reload would also work but would need a cy.wait)
-#    When I arrive on the dashboard
-#    When I go to tasks overview
-#    When I click on draft tasks tab
-#    Then I can not see task 'Cy Task Creating from Task Overview Test' on tasks overview page
+   When I click on button Cancel in confirmation window in edit task page
+   When I click on button Delete
+   When I click on button Delete in confirmation window in edit task page
+#   # new opening of the room page is necessary to clear DOM from deleted tasks (reload would also work but would need a cy.wait)
+   When I arrive on the dashboard
+   When I go to tasks overview
+   When I click on draft tasks tab
+   Then I can not see task 'Cy Task to be delete on task page' on tasks overview page

--- a/cypress/integration/features/task/createDeleteTaskFromTaskPage.feature
+++ b/cypress/integration/features/task/createDeleteTaskFromTaskPage.feature
@@ -2,29 +2,59 @@ Feature: Task - To create and delete tasks starting from task overview page by t
 
   As a teacher I want to create and delete a new task on the task overview page so that the student can submit it
 
- Scenario: As a user, I want to be able to create a simple task without course
+ Scenario: As a user, I want to be able to create simple tasks without course
    Given I am logged in as a 'teacher1' at 'brb'
    When I go to tasks overview
    When I click on button Add Task
-#    Then I am on new task page
-#    When I enter title 'Cy Task Creating from Task Overview Test'
-#    When I enter task description 'This is a task for the students.'
-#    When I click on button Submit
-#    Then I can see create task page 'Cy Task Creating from Task Overview Test'
-#    When I click on button Submit
-#    When I go to tasks page
-#    When I click on draft tab
-#    Then I can see task 'Cy Task Creating from Task Overview Test'
+   Then I can see create task page '-'
+   When I enter title 'Cy Task Creating from Task Overview Test'
+   When I enter task description 'This is a task for the students.'
+   When I click on button Submit
+   Then I can see create task page 'Cy Task Creating from Task Overview Test'
+   When I click on button Submit
+   When I go to tasks overview
+   When I click on draft tasks tab
+   Then I can see task 'Cy Task Creating from Task Overview Test' on tasks overview page
+   When I click on button Add Task
+   Then I can see create task page '-'
+   When I enter title 'Cy Task to be delete on task page'
+   When I enter task description 'This is a task to be deleted on task page.'
+   When I click on button Submit
+   Then I can see create task page 'Cy Task to be delete on task page'
+   When I click on button Submit
+   When I go to tasks overview
+   When I click on draft tasks tab
+   Then I can see task 'Cy Task to be delete on task page' on tasks overview page
 
-#  Scenario: As a user, I want to be able to delete a simple task without course
-#    Given I am logged in as 'teacher1' at 'brb'
-#    When I go to tasks page
-#    When I click on draft tab
-#    When I click on three dot menu of content 'Cy Task Creating from Task Overview Test'
-#    When I click on Delete in dot menu
-#    When I click on Delete in confirmation window
+ Scenario: As a user, I want to be able to delete a simple task without course using the dot menu
+   Given I am logged in as a 'teacher1' at 'brb'
+   When I go to tasks overview
+   When I click on draft tasks tab
+   When I click on three dot menu of task 'Cy Task Creating from Task Overview Test'
+   When I click on Delete Task in dot menu
+    And I click on Cancel in confirmation window
+   When I click on three dot menu of task 'Cy Task Creating from Task Overview Test'
+   When I click on Delete Task in dot menu
+   When I click on Delete in confirmation window
 #   # new opening of the room page is necessary to clear DOM from deleted tasks (reload would also work but would need a cy.wait)
+   When I arrive on the dashboard
+   When I go to tasks overview
+   When I click on draft tasks tab
+   Then I can not see task 'Cy Task Creating from Task Overview Test' on tasks overview page
+
+ Scenario: As a user, I want to be able to delete a simple task without course using the delete button on the task edit page
+   Given I am logged in as a 'teacher1' at 'brb'
+   When I go to tasks overview
+   When I click on draft tasks tab
+   When I click on task 'Cy Task to be delete on task page' in tasks overview
+   When I click on button Delete
+    # And I click on Cancel in confirmation window
+#     And I click on Cancel in confirmation window
+#    When I click on three dot menu of task 'Cy Task Creating from Task Overview Test'
+#    When I click on Delete Task in dot menu
+#    When I click on Delete in confirmation window
+# #   # new opening of the room page is necessary to clear DOM from deleted tasks (reload would also work but would need a cy.wait)
 #    When I arrive on the dashboard
-#    When I go to tasks page
-#    When I click on draft tab
-#    Then I can not see task 'Cy Task Creating from Task Overview Test'
+#    When I go to tasks overview
+#    When I click on draft tasks tab
+#    Then I can not see task 'Cy Task Creating from Task Overview Test' on tasks overview page

--- a/cypress/integration/features/task/createEditDeleteSubGradFinishRestoreTask.feature
+++ b/cypress/integration/features/task/createEditDeleteSubGradFinishRestoreTask.feature
@@ -8,7 +8,7 @@ Feature: Task - To create, edit and delete tasks by the teacher.
     And I go to room 'Course with subject and tasks'
     And I click on FAB to create new content
     And I click on New Task FAB
-    Then I can see create task page
+    Then I can see create task page '-'
     And file upload button is disabled
     When I enter title 'Cy Task Creating and Deleting Test'
     And I click on Enable Group Submission
@@ -17,11 +17,11 @@ Feature: Task - To create, edit and delete tasks by the teacher.
     And I set task-visibility-due-date to 'tomorrow' at '1000'
     And I enter task description 'Dies ist Deine Aufgabe.'
     And I click on button Submit
-    Then I can see create task page
+    Then I can see create task page 'Cy Task Creating and Deleting Test'
     When I go to rooms overview
     And I go to room 'Course with subject and tasks'
     Then I can see room page 'Course with subject and tasks'
-    And I can see task 'Cy Task Creating and Deleting Test'
+    And I can see task 'Cy Task Creating and Deleting Test' on course page
 
   Scenario: Teacher edits and publishes task from room via form
     Given I am logged in as a 'teacher1' at 'brb'
@@ -42,7 +42,7 @@ Feature: Task - To create, edit and delete tasks by the teacher.
     And I click on Draft Checkbox
     And I click on button Submit
     Then I can see room page 'Course with subject and tasks'
-    And I can see task 'Cy Task Creating, Editing, Deleting Test'
+    And I can see task 'Cy Task Creating, Editing, Deleting Test' on course page
     And I see task card info submitted contains "0/2" for task 'Cy Task Creating, Editing, Deleting Test'
     When I click on task 'Cy Task Creating, Editing, Deleting Test'
     Then I see description is 'Dies ist Deine Aufgabe. Viel Erfolg!'
@@ -184,7 +184,7 @@ Feature: Task - To create, edit and delete tasks by the teacher.
     When I arrive on the dashboard
     When I go to rooms overview
     And I go to room 'Course with subject and tasks'
-    Then I can see task 'Cy Task Creating, Editing, Deleting Test'
+    Then I can see task 'Cy Task Creating, Editing, Deleting Test' on course page
     When I click on three dot menu of content 'Cy Task Creating, Editing, Deleting Test'
     And I click on Delete in dot menu
     And I click on Delete in confirmation window

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -17,3 +17,9 @@
 import './commands'
 import './custom_commands/login'
 import './custom_commands/logout'
+
+
+// prevents blocking test by uncaught exception. This should be commented out when BC-2711 is resolved
+Cypress.on('uncaught:exception', (err, runnable) => {
+    return false;
+})

--- a/cypress/support/pages/tasks/pageCommonTasks.js
+++ b/cypress/support/pages/tasks/pageCommonTasks.js
@@ -5,6 +5,12 @@ class Tasks_Common {
   static #taskForm = '[id="homework-form"]'
   static #submitButton = '[data-testid="submit-task-btn"]'
   static #addTaskButton = '[data-testid="addTask"]'
+  static #taskNameInput = '[data-testid="homework-name"]'
+  static #homeWorkDescriptionP = '[class="ck ck-editor__main"]'
+  static #draftTasksTab = '[data-testid="draftTasks"]'
+  static #taskCardTitle = '[data-testid="taskTitle"]'
+  static #taskMenuDelete = '[data-testid="task-delete"]'
+  static #deleteTaskButton = '[data-testid="task-details-btn-delete"]'
 
   navigateToTasksOverview() {
     cy.visit('/tasks')
@@ -14,11 +20,94 @@ class Tasks_Common {
 
   clickOnSubmit() {
     cy.get(Tasks_Common.#taskForm).find(Tasks_Common.#submitButton).click()
+    // next lines can be removed when BC-2711 is resolved
+    Cypress.on('uncaught:exception', (err, runnable) => {
+      return false;
+    })
     //cy.get(Tasks_Common.#submitButton).should('contain', '').click()
   }
 
   clickOnAddTask() {
     cy.get(Tasks_Common.#addTaskButton).click()
   }
+
+  seeCreateTaskPage (taskTitle) {
+    if (taskTitle === '-'){
+      cy.get(Tasks_Common.#taskForm)
+        .get(Tasks_Common.#taskNameInput)
+        .should('be.empty')
+    } else {
+      cy.get(Tasks_Common.#taskForm)
+        .get(Tasks_Common.#taskNameInput)
+        .should('have.value', taskTitle)
+    }
+  }
+
+  enterTaskTitle (taskTitle) {
+    cy.get(Tasks_Common.#taskNameInput).clear()
+    cy.get(Tasks_Common.#taskNameInput).type(taskTitle)
+  }
+
+  setTaskText (taskText) {
+    cy.get(Tasks_Common.#homeWorkDescriptionP)
+      .find('div > p')
+      .clear()
+    cy.get(Tasks_Common.#homeWorkDescriptionP)
+      .find('div > p')
+      .type(taskText)
+  }
+
+  clickOnTabDraftTasks () {
+    cy.get(Tasks_Common.#draftTasksTab).click()
+  }
+
+
+  taskIsVisibleOnTasksOverviewPage (taskTitle) {
+    cy.reload() // Reload is necessary because after deletion of a content element a message window with its title stays hidden in the DOM
+    cy.url().should('include', '/tasks')
+    cy.contains(taskTitle)
+      .should('be.visible')
+      .wait([
+        '@public_api',
+        '@me_api',
+        '@roles_api',
+        '@schools_api'
+      ])
+      .then(interceptions => {
+        expect(interceptions[0].response.statusCode).to.equal(200)
+        expect(interceptions[1].state).to.equal('Complete')
+        expect(interceptions[1].response.statusCode).to.equal(200)
+      })
+  }
+
+
+  taskIsNotVisibleOnTasksOverviewPage (taskTitle) {
+    cy.wait(200)
+    cy.contains(taskTitle).should('not.exist')
+  }
+
+  openThreeDotMenuForTask (taskTitle) {
+    cy.get(Tasks_Common.#taskCardTitle)
+      .contains(taskTitle)
+      .parent()
+      .parent()
+      .find('button')
+      .click()
+  }
+
+  openTaskFromTasksOverview (taskTitle) {
+    cy.get(Tasks_Common.#taskCardTitle)
+      .contains(taskTitle)
+      .click()
+  }
+
+  clickDeleteTaskInDotMenu () {
+    cy.get(Tasks_Common.#taskMenuDelete).click()
+  }
+
+  clickButtonDeleteTask () {
+    cy.get(Tasks_Common.#deleteTaskButton).click()
+  }
+
 }
 export default Tasks_Common

--- a/cypress/support/pages/tasks/pageCommonTasks.js
+++ b/cypress/support/pages/tasks/pageCommonTasks.js
@@ -4,6 +4,7 @@ class Tasks_Common {
   static #tasksOverviewNavigationButton = '[data-testid="Aufgaben"]'
   static #taskForm = '[id="homework-form"]'
   static #submitButton = '[data-testid="submit-task-btn"]'
+  static #addTaskButton = '[data-testid="addTask"]'
 
   navigateToTasksOverview() {
     cy.visit('/tasks')
@@ -14,6 +15,10 @@ class Tasks_Common {
   clickOnSubmit() {
     cy.get(Tasks_Common.#taskForm).find(Tasks_Common.#submitButton).click()
     //cy.get(Tasks_Common.#submitButton).should('contain', '').click()
+  }
+
+  clickOnAddTask() {
+    cy.get(Tasks_Common.#addTaskButton).click()
   }
 }
 export default Tasks_Common

--- a/cypress/support/pages/tasks/pageCommonTasks.js
+++ b/cypress/support/pages/tasks/pageCommonTasks.js
@@ -20,10 +20,6 @@ class Tasks_Common {
 
   clickOnSubmit() {
     cy.get(Tasks_Common.#taskForm).find(Tasks_Common.#submitButton).click()
-    // next lines can be removed when BC-2711 is resolved
-    Cypress.on('uncaught:exception', (err, runnable) => {
-      return false;
-    })
     //cy.get(Tasks_Common.#submitButton).should('contain', '').click()
   }
 

--- a/cypress/support/pages/tasks/pageTasks.js
+++ b/cypress/support/pages/tasks/pageTasks.js
@@ -12,6 +12,7 @@ class Tasks {
   static #publicSubmissionsCheckbox = '[id="publicSubmissionsCheckbox"]'
   static #dialogConfirmButton = '[data-testid="task-publicSubmissions-dialog-confirm"]'
   static #dialogCancelButton = '[data-testid="task-publicSubmissions-dialog-cancel"]'
+  static #dialogCancelDeleteTaskButtons = '[id="modal-delete-homework-footer"]'
   static #taskDetailsTab = '[id="extended"]'
   static #submissionTab = '[id="submission-tab-link"]'
   static #submissionsTab = '[id="submissions-tab-link"]'
@@ -48,6 +49,20 @@ class Tasks {
   static #finishedTasksListDiv = '[id="finished"]'
   static #taskDotMenu = '[data-testid="task-menu"]'
   static #taskFinishButtonInDotMenu = '[data-testid="task-finish"]'
+
+  clickCancelDeletionButtonInEditTask () {
+    cy.get(Tasks.#dialogCancelDeleteTaskButtons)
+      .find('button')
+      .eq(0)
+      .click()
+  }
+
+  clickConfirmDeletionButtonInEditTask () {
+    cy.get(Tasks.#dialogCancelDeleteTaskButtons)
+      .find('button')
+      .eq(1)
+      .click()
+  }
 
   compareFeedbackText (feedbackText) {
     cy.get(Tasks.#feedbackSection).should('contain', feedbackText)

--- a/cypress/support/pages/tasks/pageTasks.js
+++ b/cypress/support/pages/tasks/pageTasks.js
@@ -5,13 +5,10 @@ class Tasks {
   static #localeDateFormat = 'de-DE'
   static #taskOverviewTeacher = '[class="task-dashboard-teacher"]'
   static #taskOverviewStudent = '[class="task-dashboard-student"]'
-  static #createForm = '[id="homework-form"]'
-  static #taskNameInput = '[data-testid="homework-name"]'
   static #groupSubmissionCheckbox = '[id="teamSubmissions"]'
   static #draftCheckbox = '[data-testid="private-checkbox"]'
   static #visibilityStartDateInput = '[data-testid="form-datetime-input-availableDate"]'
   static #visibilityDueDateInput = '[data-testid="form-datetime-input-dueDate"]'
-  static #homeWorkDescriptionP = '[class="ck ck-editor__main"]'
   static #publicSubmissionsCheckbox = '[id="publicSubmissionsCheckbox"]'
   static #dialogConfirmButton = '[data-testid="task-publicSubmissions-dialog-confirm"]'
   static #dialogCancelButton = '[data-testid="task-publicSubmissions-dialog-cancel"]'
@@ -60,23 +57,12 @@ class Tasks {
     cy.get(Tasks.#feedbackSection).should('contain', feedbackGrade)
   }
 
-  seeCreateTaskPage () {
-    cy.get(Tasks.#createForm)
-      .get(Tasks.#taskNameInput)
-      .should('be.empty')
-  }
-
   seeUploadFileButtonIsDisabled () {
     cy.get(Tasks.#fileUploadButtonDisabled).should('be.visible')
   }
 
   seeUploadFileButtonIsEnabled () {
     cy.get(Tasks.#fileUploadButtonEnabled).should('be.visible')
-  }
-
-  enterTaskTitle (taskTitle) {
-    cy.get(Tasks.#taskNameInput).clear()
-    cy.get(Tasks.#taskNameInput).type(taskTitle)
   }
 
   clickOnGroupSubmissionCheckbox () {
@@ -123,15 +109,6 @@ class Tasks {
     cy.get(Tasks.#visibilityDueDateInput).type(
       `{selectAll}${startDueText}${visibilityDueTime}`
     )
-  }
-
-  setTaskText (taskText) {
-    cy.get(Tasks.#homeWorkDescriptionP)
-      .find('div > p')
-      .clear()
-    cy.get(Tasks.#homeWorkDescriptionP)
-      .find('div > p')
-      .type(taskText)
   }
 
   executeFileUpload (fileName) {

--- a/cypress/support/step_definition/course/commonCourseSteps.spec.js
+++ b/cypress/support/step_definition/course/commonCourseSteps.spec.js
@@ -51,7 +51,7 @@ And('I click on New Task FAB', () => {
   coursesCommon.clickOnNewTaskFAB()
 })
 
-And('I can see task {string}', taskTitle => {
+And('I can see task {string} on course page', taskTitle => {
   coursesCommon.taskIsVisibleOnCoursePage(taskTitle)
 })
 

--- a/cypress/support/step_definition/tasks/commonTaskSteps.spec.js
+++ b/cypress/support/step_definition/tasks/commonTaskSteps.spec.js
@@ -9,3 +9,7 @@ When('I go to tasks overview', () => {
 And('I click on button Submit', () => {
   tasksCommon.clickOnSubmit()
 })
+
+When('I click on button Add Task', () => {
+  tasksCommon.clickOnAddTask()
+})

--- a/cypress/support/step_definition/tasks/commonTaskSteps.spec.js
+++ b/cypress/support/step_definition/tasks/commonTaskSteps.spec.js
@@ -13,3 +13,52 @@ And('I click on button Submit', () => {
 When('I click on button Add Task', () => {
   tasksCommon.clickOnAddTask()
 })
+
+Then('I can see create task page {string}', (taskTitle) => {
+  tasksCommon.seeCreateTaskPage(taskTitle)
+})
+
+When ('I enter title {string}', (taskTitle) => {
+  tasksCommon.enterTaskTitle(taskTitle)
+})
+
+And ('I enter task description {string}', (taskDescription) => {
+  tasksCommon.setTaskText(taskDescription)
+})
+
+And ('I enter text submission {string}', (submissionText) => {
+  tasksCommon.setTaskText(submissionText)
+})
+
+And ('I enter comment {string}', (gradingText) => {
+  tasksCommon.setTaskText(gradingText)
+})
+
+When('I click on draft tasks tab', () => {
+  tasksCommon.clickOnTabDraftTasks()
+})
+
+Then('I can see task {string} on tasks overview page', taskTitle => {
+  tasksCommon.taskIsVisibleOnTasksOverviewPage(taskTitle)
+})
+
+Then('I can not see task {string} on tasks overview page', taskTitle => {
+  tasksCommon.taskIsNotVisibleOnTasksOverviewPage(taskTitle)
+})
+
+When('I click on three dot menu of task {string}', contentTitle => {
+  tasksCommon.openThreeDotMenuForTask(contentTitle)
+})
+
+When('I click on Delete Task in dot menu', () => {
+  tasksCommon.clickDeleteTaskInDotMenu()
+})
+
+When('I click on task {string} in tasks overview', contentTitle => {
+  tasksCommon.openTaskFromTasksOverview(contentTitle)
+})
+
+When('I click on button Delete', () => {
+  tasksCommon.clickButtonDeleteTask()
+})
+

--- a/cypress/support/step_definition/tasks/createDeleteTaskFromTaskPage.spec.js
+++ b/cypress/support/step_definition/tasks/createDeleteTaskFromTaskPage.spec.js
@@ -9,3 +9,4 @@ const tasks = new Tasks()
 // -->\step_definition\authentication\loginStep.spec.js
 // -->\step_definition\course\commonCourseSteps.spec.js
 // -->\step_definition\tasks\commonTaskSteps.spec.js
+

--- a/cypress/support/step_definition/tasks/createDeleteTaskFromTaskPage.spec.js
+++ b/cypress/support/step_definition/tasks/createDeleteTaskFromTaskPage.spec.js
@@ -1,0 +1,11 @@
+import Tasks from '../../pages/tasks/pageTasks'
+
+const tasks = new Tasks()
+
+// EXTERNAL COMMON STEP DEFINITIONS
+// =========================
+// External defined steps can be found here:
+// -----------------------------------------
+// -->\step_definition\authentication\loginStep.spec.js
+// -->\step_definition\course\commonCourseSteps.spec.js
+// -->\step_definition\tasks\commonTaskSteps.spec.js

--- a/cypress/support/step_definition/tasks/createDeleteTaskFromTaskPage.spec.js
+++ b/cypress/support/step_definition/tasks/createDeleteTaskFromTaskPage.spec.js
@@ -10,3 +10,10 @@ const tasks = new Tasks()
 // -->\step_definition\course\commonCourseSteps.spec.js
 // -->\step_definition\tasks\commonTaskSteps.spec.js
 
+When('I click on button Cancel in confirmation window in edit task page', () => {
+    tasks.clickCancelDeletionButtonInEditTask()
+})
+
+When('I click on button Delete in confirmation window in edit task page', () => {
+    tasks.clickConfirmDeletionButtonInEditTask()
+})

--- a/cypress/support/step_definition/tasks/createEditDeleteSubGradFinishRestoreTask.spec.js
+++ b/cypress/support/step_definition/tasks/createEditDeleteSubGradFinishRestoreTask.spec.js
@@ -10,16 +10,8 @@ const tasks = new Tasks()
 // -->\step_definition\course\commonCourseSteps.spec.js
 // -->\step_definition\tasks\commonTaskSteps.spec.js
 
-Then('I can see create task page', () => {
-  tasks.seeCreateTaskPage()
-})
-
 And('file upload button is disabled', () => {
   tasks.seeUploadFileButtonIsDisabled()
-})
-
-When ('I enter title {string}', (taskTitle) => {
-  tasks.enterTaskTitle(taskTitle)
 })
 
 And ('I click on Enable Group Submission', () => {
@@ -36,10 +28,6 @@ And ('I set task-visibility-start-date to {string} at {string}', (visibilityStar
 
 And ('I set task-visibility-due-date to {string} at {string}', (visibilityDueDate, visibilityDueTime) => {
   tasks.setVisibilityDueDate(visibilityDueDate, visibilityDueTime)
-})
-
-And ('I enter task description {string}', (taskDescription) => {
-  tasks.setTaskText(taskDescription)
 })
 
 Then('I see file upload button is enabled', () => {
@@ -158,10 +146,6 @@ Then('I see detail page for task {string}', (taskTitle) => {
   tasks.seeDetailPageForTask(taskTitle)
 })
 
-And ('I enter text submission {string}', (submissionText) => {
-  tasks.setTaskText(submissionText)
-})
-
 And('I click on button Save and Send Submission', () => {
   tasks.clickSaveAndSendSubmissionBtn()
 })
@@ -224,10 +208,6 @@ When('I click on grading tab', () => {
 
 When('I click on submission tab', () => {
   tasks.clickSubmissionTab()
-})
-
-And ('I enter comment {string}', (gradingText) => {
-  tasks.setTaskText(gradingText)
 })
 
 And('I enter grade {string}', (gradingPercent) => {


### PR DESCRIPTION
# Description

Test implemented as requested in BC-1875, also added a scenario for deleting a task on the task detail page.

## Links to Tickets or other pull requests
https://ticketsystem.dbildungscloud.de/browse/BC-1875

<!--
Base links to copy
- https://github.com/hpi-schul-cloud/schulcloud-server/pull/????
- https://ticketsystem.dbildungscloud.de/browse/BC-????
-->

## Changes

<!--
  What will the PR change?
  Why are the changes requiered?
  Short notice if a ticket exists, more detailed if not
-->

## Datasecurity

<!--
  Notice about:
  - model changes
  - logging of user data
  - right changes
  - and other user data stuff
  If you are not sure if it is relevant, take a look at confluence or ask the data-security team.
-->

## Deployment

<!--
  Keep in mind to changes to seed data, if changes are done by migration scripts.
  Changes to the infrastructure have to discussed with the devops

  This point should includes following informations:
  - What is required for deployment?
  - Envirement variables like FEATURE_XY=true
  - Migration scripts to run, other requirements
-->

## New Repos, NPM pakages or vendor scripts

<!--
  Keep in mind the stability, performance, activity and author.

  Describe why it is needed.
-->

## Screenshots of UI changes

<!--
  only needed for visual changes

  If visual changes exist, work together with UI/UX from beginning/ping UX with final PR
-->

## Approval for review

- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.
