### PR TITLE
Bc 2800 lower task section icon not unique

### DIFF
--- a/cypress/support/pages/tasks/pageTasks.js
+++ b/cypress/support/pages/tasks/pageTasks.js
@@ -365,8 +365,10 @@ class Tasks {
   }
 
   openNotGradedTasks () {
-    cy.get(Tasks.#lowerTaskSectionIcon)
+    cy.get(Tasks.#taskOverviewStudent)
+      .find('section')
       .eq(1)
+      .find(Tasks.#lowerTaskSectionIcon)
       .click()
   }
 


### PR DESCRIPTION
# Description

Fixes Test automation bug: data-testid lowerTaskSectionIcon sometimes not unique.
The element to click now is addressed by using the parent section.

## Links to Tickets or other pull requests

<!--
Base links to copy
- https://github.com/hpi-schul-cloud/schulcloud-server/pull/????
- https://ticketsystem.dbildungscloud.de/browse/BC-????
-->

## Changes

<!--
  What will the PR change?
  Why are the changes requiered?
  Short notice if a ticket exists, more detailed if not
-->

## Datasecurity

<!--
  Notice about:
  - model changes
  - logging of user data
  - right changes
  - and other user data stuff
  If you are not sure if it is relevant, take a look at confluence or ask the data-security team.
-->

## Deployment

<!--
  Keep in mind to changes to seed data, if changes are done by migration scripts.
  Changes to the infrastructure have to discussed with the devops

  This point should includes following informations:
  - What is required for deployment?
  - Envirement variables like FEATURE_XY=true
  - Migration scripts to run, other requirements
-->

## New Repos, NPM pakages or vendor scripts

<!--
  Keep in mind the stability, performance, activity and author.

  Describe why it is needed.
-->

## Screenshots of UI changes

<!--
  only needed for visual changes

  If visual changes exist, work together with UI/UX from beginning/ping UX with final PR
-->

## Approval for review

- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.
