### PR TITLE
unnecessary steps removed

### DIFF
--- a/cypress/integration/features/task/createEditDeleteSubGradFinishRestoreTask.feature
+++ b/cypress/integration/features/task/createEditDeleteSubGradFinishRestoreTask.feature
@@ -124,9 +124,6 @@ Feature: Task - To create, edit and delete tasks by the teacher.
     Then file 'testboard_jpg' is saved in folder downloads
     When I click on grading tab
     And I upload file 'gradingfile-pdf.pdf'
-    And I click on submissions tab
-    And I click on submission of 'Kraft'
-    And I click on grading tab
     Then I see file 'gradingfile-pdf.pdf' is visible in uploaded files section
     And I enter comment 'Gut gemacht!'
     And I enter grade '83'


### PR DESCRIPTION
# Description

BC-1558 changed the process of file upload: after file upload the page reloads and the grading stays visible, so the steps to open grading again caused issues. I removed them, now it is running without issues.

## Links to Tickets or other pull requests

<!--
Base links to copy
- https://github.com/hpi-schul-cloud/schulcloud-server/pull/????
- https://ticketsystem.dbildungscloud.de/browse/BC-????
-->

## Changes

<!--
  What will the PR change?
  Why are the changes requiered?
  Short notice if a ticket exists, more detailed if not
-->

## Datasecurity

<!--
  Notice about:
  - model changes
  - logging of user data
  - right changes
  - and other user data stuff
  If you are not sure if it is relevant, take a look at confluence or ask the data-security team.
-->

## Deployment

<!--
  Keep in mind to changes to seed data, if changes are done by migration scripts.
  Changes to the infrastructure have to discussed with the devops

  This point should includes following informations:
  - What is required for deployment?
  - Envirement variables like FEATURE_XY=true
  - Migration scripts to run, other requirements
-->

## New Repos, NPM pakages or vendor scripts

<!--
  Keep in mind the stability, performance, activity and author.

  Describe why it is needed.
-->

## Screenshots of UI changes

<!--
  only needed for visual changes

  If visual changes exist, work together with UI/UX from beginning/ping UX with final PR
-->

## Approval for review

- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.
