### PR TITLE
hotfix: using an absolute path for script execution in GitHub Actions to avoid path resolution issues

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,10 +56,10 @@ jobs:
         id: read_variables
         run: |
           workflow=${{ github.workflow }}
-          workspace_path=${{ github.workspace }}
+          workspace_path=/home/runner/work/e2e-system-tests/e2e-system-tests
 
-          chmod +x ${{ github.workspace }}/e2e-system-tests/scripts/aggregate-json-files.sh
-          ${{ github.workspace }}/e2e-system-tests/scripts/aggregate-json-files.sh \
+          chmod +x ${workspace_path}/e2e-system-tests/scripts/aggregate-json-files.sh
+          ${workspace_path}/e2e-system-tests/scripts/aggregate-json-files.sh \
             "${workflow}" \
             "${{ inputs.cypress_brb }}" \
             "${{ inputs.cypress_default }}" \


### PR DESCRIPTION
# Description

When using the `${{github.workspace}}` environment variable in GitHub Actions, the path it resolves to depends on whether the workflow is defined in the same repo or called remotely. In the case of a remote workflow, the path points to the parent repo, which can cause issues if the script tries to access files or directories from the e2e repo. To resolve this, you should use an absolute path to the script instead of relying on `{{github.workspace}}`. This will ensure that the script is executed from the correct location regardless of the repo where it's called.


## Links to Tickets or other pull requests

<!--
Base links to copy
- https://github.com/hpi-schul-cloud/schulcloud-server/pull/????
- https://ticketsystem.dbildungscloud.de/browse/BC-????
-->

## Changes

<!--
  What will the PR change?
  Why are the changes requiered?
  Short notice if a ticket exists, more detailed if not
-->

## Datasecurity

<!--
  Notice about:
  - model changes
  - logging of user data
  - right changes
  - and other user data stuff
  If you are not sure if it is relevant, take a look at confluence or ask the data-security team.
-->

## Deployment

<!--
  Keep in mind to changes to seed data, if changes are done by migration scripts.
  Changes to the infrastructure have to discussed with the devops

  This point should includes following informations:
  - What is required for deployment?
  - Envirement variables like FEATURE_XY=true
  - Migration scripts to run, other requirements
-->

## New Repos, NPM pakages or vendor scripts

<!--
  Keep in mind the stability, performance, activity and author.

  Describe why it is needed.
-->

## Screenshots of UI changes

<!--
  only needed for visual changes

  If visual changes exist, work together with UI/UX from beginning/ping UX with final PR
-->

## Approval for review

- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.
