### PR TITLE
BC-11691 Updated news tests and added address link in ck

### DIFF
--- a/cypress/e2e/news/createReadDeleteSchoolNewsInAdvance.feature
+++ b/cypress/e2e/news/createReadDeleteSchoolNewsInAdvance.feature
@@ -19,10 +19,14 @@ Feature:  News - To read a news on the respective dashboards
         Then I see news creation page
         When I enter news title '<news_title>'
         When I enter news description '<news_description>'
+        When I click on the button Add link in the ckeditor
+        When I enter the link '<link_url>' in the link address tool
+        When I click on the icon save in address link tool
         When I set news-visibility-start-date to '<news_day_from_today>' days at '<news_time>'
         Then I see time input field
         When I click on save button
         Then I can read the news '<news_title>' with description '<news_description>' on news detail page
+        Then I see the link URL '<link_url>' on news detail page
         When I go to news overview
         Then I do not see the unpublished news '<news_title>'
         When I click on tab for unpublished news
@@ -36,6 +40,7 @@ Feature:  News - To read a news on the respective dashboards
         Then I can read the news '<news_title>' with description '<news_description>'
         When I click on the news teaser '<news_title>'
         Then I can read the news '<news_title>' with description '<news_description>' on news detail page
+        Then I see the link URL '<link_url>' on news detail page
 
         # post-condition: first user deletes the school news
         Given I am logged in as a '<news_author>' at '<namespace>'
@@ -50,5 +55,5 @@ Feature:  News - To read a news on the respective dashboards
         @school_api_test
         @staging_test
         Examples:
-            | news_author  | news_reader  | namespace | news_title                          | news_description          | news_day_from_today | news_time | news_waiting_time |
-            | teacher1_brb | student1_brb | brb       | CypressAut - school news in advance | Remember Examination date | 0                   | +2minutes | 120               |
+            | news_author  | news_reader  | namespace | news_title                          | news_description          | news_day_from_today | news_time | news_waiting_time | link_url                                 |
+            | teacher1_brb | student1_brb | brb       | CypressAut - school news in advance | Remember Examination date | 0                   | +2minutes | 120               | https://main.brb.dbildungscloud.dev/news |

--- a/cypress/support/pages/news/pageNews.js
+++ b/cypress/support/pages/news/pageNews.js
@@ -28,8 +28,8 @@ class News {
 	static #pageTitleLegacy = '[id="page-title"]';
 	static #ckBalloonPanelButton = ".ck-balloon-panel button";
 	static #ckLabeledFieldViewInputWrapper = ".ck-labeled-field-view__input-wrapper";
-	static #newsTimeInfo = '[data-testid="news-last-touched"]';
 	static #newsDetailPageHeader = "h1";
+	static #newsTimeInfo = '[data-testid="news-last-touched"]';
 
 	clickAddLinkInCKEditor() {
 		cy.get(News.#inlineCkToolbar).realClick();
@@ -226,19 +226,24 @@ class News {
 	}
 
 	seeNewsTimeInfoOnNewsDetailPage(newsTimeInfo) {
+		const daysFromNow = parseInt(newsTimeInfo, 10);
+		const targetSelector =
+			daysFromNow === -7 ? News.#newsDetailPageHeader : News.#newsTimeInfo;
+
 		if (newsTimeInfo === "vor ein") {
-			cy.get(News.#newsTimeInfo).contains(newsTimeInfo).should("exist");
-		} else {
-			let daysFromNow = parseInt(newsTimeInfo);
-			let startDate = new Date();
-			startDate.setDate(startDate.getDate() + daysFromNow);
-			let newsDateInfo = startDate.toLocaleString(News.#deDateFormat, {
-				year: "numeric",
-				day: "2-digit",
-				month: "2-digit",
-			});
-			cy.get(News.#newsTimeInfo).contains(newsDateInfo).should("exist");
+			cy.get(targetSelector).contains(newsTimeInfo).should("exist");
+			return;
 		}
+
+		let startDate = new Date();
+		startDate.setDate(startDate.getDate() + daysFromNow);
+		let newsDateInfo = startDate.toLocaleString(News.#deDateFormat, {
+			year: "numeric",
+			day: "2-digit",
+			month: "2-digit",
+		});
+
+		cy.get(targetSelector).contains(newsDateInfo).should("exist");
 	}
 
 	seeNewsTimeInfoOnOverviewPage(newsTimeInfo) {

--- a/cypress/support/pages/news/pageNews.js
+++ b/cypress/support/pages/news/pageNews.js
@@ -23,7 +23,7 @@ class News {
 	static #titlebarNewsOverviewPage = '[id="titlebar"]';
 	//static #newsMainContent = '[id="main-content"]';
 	static #newsOverviewTabUnpublished = '[data-tab="b"]';
-	static #inlineCkToolbar = '[data-cke-tooltip-text="Link (Ctrl+K)"]';
+	static #inlineCkToolbar = '[data-cke-tooltip-text^="Link"]';
 	static #newsContent = '[data-testid="news-content"]';
 	static #pageTitleLegacy = '[id="page-title"]';
 	static #ckBalloonPanelButton = ".ck-balloon-panel button";

--- a/cypress/support/pages/news/pageNews.js
+++ b/cypress/support/pages/news/pageNews.js
@@ -18,16 +18,18 @@ class News {
 	static #newsDescriptionVisible = '[data-testid="news-content"]';
 	static #newsNameOnNewsOverview = '[data-testid="title_of_an_element"]';
 	static #newsNameOnDashboard = '[data-testid="news-title"]';
-	static #deleteNews = '[data-testid="btn-delete-news"]';
-	static #deleteNewsConfirmation = '[data-testid="delete-article-btn"]';
+	static #deleteNews = '[data-testid="news-delete-btn"]';
+	static #deleteNewsConfirmation = '[data-testid="confirm-dialog-confirm"]';
 	static #titlebarNewsOverviewPage = '[id="titlebar"]';
-	static #newsMainContent = '[id="main-content"]';
+	//static #newsMainContent = '[id="main-content"]';
 	static #newsOverviewTabUnpublished = '[data-tab="b"]';
 	static #inlineCkToolbar = '[data-cke-tooltip-text="Link (Ctrl+K)"]';
 	static #newsContent = '[data-testid="news-content"]';
 	static #pageTitleLegacy = '[id="page-title"]';
 	static #ckBalloonPanelButton = ".ck-balloon-panel button";
 	static #ckLabeledFieldViewInputWrapper = ".ck-labeled-field-view__input-wrapper";
+	static #newsTimeInfo = '[data-testid="news-last-touched"]';
+	static #newsDetailPageHeader = "h1";
 
 	clickAddLinkInCKEditor() {
 		cy.get(News.#inlineCkToolbar).realClick();
@@ -102,6 +104,7 @@ class News {
 	}
 
 	seeCreatedNews(newsTitle, newsDesc) {
+		cy.get(News.#newsDetailPageHeader).should("contain.text", "Neuigkeit vom");
 		cy.get(News.#newsTitle).contains(newsTitle);
 		cy.get(News.#newsDescriptionVisible).contains(newsDesc);
 	}
@@ -152,14 +155,12 @@ class News {
 	}
 
 	seeNewsOnNewsDetailPage(titleOfNews, descriptionOfNews) {
-		const titleSelectors = `${News.#pageTitle}, ${News.#pageTitleLegacy}`;
-		cy.get(titleSelectors).contains(titleOfNews).should("exist");
-		cy.get(News.#newsMainContent).contains(descriptionOfNews).should("exist");
+		cy.get(News.#pageTitle).contains(titleOfNews).should("exist");
+		cy.get(News.#newsContent).contains(descriptionOfNews).should("exist");
 	}
 
 	seeLinkUrlOnNewsDetailPage(linkUrl) {
-		const contentSelectors = `${News.#newsContent}, ${News.#newsMainContent}`;
-		cy.get(contentSelectors).contains(linkUrl).should("exist");
+		cy.get(News.#newsContent).contains(linkUrl).should("exist");
 	}
 
 	setNewsStartDate(newsStartDateDifference, newsStartTime) {
@@ -226,7 +227,7 @@ class News {
 
 	seeNewsTimeInfoOnNewsDetailPage(newsTimeInfo) {
 		if (newsTimeInfo === "vor ein") {
-			cy.get(News.#newsMainContent).contains(newsTimeInfo).should("exist");
+			cy.get(News.#newsTimeInfo).contains(newsTimeInfo).should("exist");
 		} else {
 			let daysFromNow = parseInt(newsTimeInfo);
 			let startDate = new Date();
@@ -236,7 +237,7 @@ class News {
 				day: "2-digit",
 				month: "2-digit",
 			});
-			cy.get(News.#newsMainContent).contains(newsDateInfo).should("exist");
+			cy.get(News.#newsTimeInfo).contains(newsDateInfo).should("exist");
 		}
 	}
 

--- a/cypress/support/pages/news/pageNews.js
+++ b/cypress/support/pages/news/pageNews.js
@@ -3,7 +3,7 @@
 class News {
 	static #elementTitle = '[data-testid="title_of_an_element"]';
 	static #elementHeader = '[data-testid="header-of-element"]';
-	static #pageTitle = '[id="page-title"]';
+	static #pageTitle = '[data-testid="news-title"]';
 	static #enDateFormat = "en-CA";
 	static #deDateFormat = "de-DE";
 	static #newsText = '[data-testid="body_of_element"]';
@@ -14,15 +14,39 @@ class News {
 	static #newsDateInput = '[data-testid="news_date"]';
 	static #newsTimeInput = '[data-testid="news_time"]';
 	static #newsCreateButton = '[data-testid="btn_news_submit"]';
-	static #newsTitle = '[id="page-title"]';
-	static #newsDescriptionVisible = '[class="ckcontent"]';
+	static #newsTitle = '[data-testid="news-title"]';
+	static #newsDescriptionVisible = '[data-testid="news-content"]';
 	static #newsNameOnNewsOverview = '[data-testid="title_of_an_element"]';
 	static #newsNameOnDashboard = '[data-testid="news-title"]';
 	static #deleteNews = '[data-testid="btn-delete-news"]';
 	static #deleteNewsConfirmation = '[data-testid="delete-article-btn"]';
 	static #titlebarNewsOverviewPage = '[id="titlebar"]';
-	static #newsContent = '[id="main-content"]';
+	static #newsMainContent = '[id="main-content"]';
 	static #newsOverviewTabUnpublished = '[data-tab="b"]';
+	static #inlineCkToolbar = '[data-cke-tooltip-text="Link (Ctrl+K)"]';
+	static #newsContent = '[data-testid="news-content"]';
+	static #pageTitleLegacy = '[id="page-title"]';
+	static #ckBalloonPanelButton = ".ck-balloon-panel button";
+	static #ckLabeledFieldViewInputWrapper = ".ck-labeled-field-view__input-wrapper";
+
+	clickAddLinkInCKEditor() {
+		cy.get(News.#inlineCkToolbar).realClick();
+	}
+
+	enterLinkInLinkAddressTool(linkUrl) {
+		cy.contains(
+			News.#ckLabeledFieldViewInputWrapper,
+			/Linkadresse|Link address|Link URL/i
+		)
+			.find("input")
+			.should("be.visible")
+			.clear()
+			.type(linkUrl);
+	}
+
+	clickSaveIconInCKEditor() {
+		cy.contains(News.#ckBalloonPanelButton, /Save|Speichern/i).click();
+	}
 
 	doNotSeeNewsWhenNewsNotYetPublished(newsTitle) {
 		cy.get("span", { timeout: 20000 }).then(($span) => {
@@ -128,8 +152,14 @@ class News {
 	}
 
 	seeNewsOnNewsDetailPage(titleOfNews, descriptionOfNews) {
-		cy.get(News.#pageTitle).contains(titleOfNews).should("exist");
-		cy.get(News.#newsContent).contains(descriptionOfNews).should("exist");
+		const titleSelectors = `${News.#pageTitle}, ${News.#pageTitleLegacy}`;
+		cy.get(titleSelectors).contains(titleOfNews).should("exist");
+		cy.get(News.#newsMainContent).contains(descriptionOfNews).should("exist");
+	}
+
+	seeLinkUrlOnNewsDetailPage(linkUrl) {
+		const contentSelectors = `${News.#newsContent}, ${News.#newsMainContent}`;
+		cy.get(contentSelectors).contains(linkUrl).should("exist");
 	}
 
 	setNewsStartDate(newsStartDateDifference, newsStartTime) {
@@ -196,7 +226,7 @@ class News {
 
 	seeNewsTimeInfoOnNewsDetailPage(newsTimeInfo) {
 		if (newsTimeInfo === "vor ein") {
-			cy.get(News.#newsContent).contains(newsTimeInfo).should("exist");
+			cy.get(News.#newsMainContent).contains(newsTimeInfo).should("exist");
 		} else {
 			let daysFromNow = parseInt(newsTimeInfo);
 			let startDate = new Date();
@@ -206,7 +236,7 @@ class News {
 				day: "2-digit",
 				month: "2-digit",
 			});
-			cy.get(News.#newsContent).contains(newsDateInfo).should("exist");
+			cy.get(News.#newsMainContent).contains(newsDateInfo).should("exist");
 		}
 	}
 

--- a/cypress/support/step_definition/news/commonNewsSteps.spec.js
+++ b/cypress/support/step_definition/news/commonNewsSteps.spec.js
@@ -3,6 +3,18 @@ import News from "../../pages/news/pageNews";
 
 const news = new News();
 
+When("I click on the button Add link in the ckeditor", () => {
+	news.clickAddLinkInCKEditor();
+});
+
+When("I enter the link {string} in the link address tool", (linkUrl) => {
+	news.enterLinkInLinkAddressTool(linkUrl);
+});
+
+When("I click on the icon save in address link tool", () => {
+	news.clickSaveIconInCKEditor();
+});
+
 When("I go to news overview", () => {
 	news.navigateToNewsOverview();
 });
@@ -62,17 +74,23 @@ Then("I do not see the unpublished news {string}", (newsName) => {
 	news.doNotSeeNewsWhenNewsNotYetPublished(newsName);
 });
 
-When("I set news-visibility-start-date to {string} days at {string}", (newsDayDifference, newsTime) => {
-	news.setNewsStartDate(newsDayDifference, newsTime);
-});
+When(
+	"I set news-visibility-start-date to {string} days at {string}",
+	(newsDayDifference, newsTime) => {
+		news.setNewsStartDate(newsDayDifference, newsTime);
+	}
+);
 
 When("I can see the publishing time info {string} on overview page", (newsTimeInfo) => {
 	news.seeNewsTimeInfoOnOverviewPage(newsTimeInfo);
 });
 
-When("I can see the publishing time info {string} on news detail page", (newsTimeInfo) => {
-	news.seeNewsTimeInfoOnNewsDetailPage(newsTimeInfo);
-});
+When(
+	"I can see the publishing time info {string} on news detail page",
+	(newsTimeInfo) => {
+		news.seeNewsTimeInfoOnNewsDetailPage(newsTimeInfo);
+	}
+);
 
 Then(
 	"I can read the news {string} with description {string} on news detail page",
@@ -81,16 +99,18 @@ Then(
 	}
 );
 
+Then("I see the link URL {string} on news detail page", (linkUrl) => {
+	news.seeLinkUrlOnNewsDetailPage(linkUrl);
+});
+
 When("I wait {string} seconds and reload", (timeInSeconds) => {
-	news.waitBeforeReload(timeInSeconds)
+	news.waitBeforeReload(timeInSeconds);
 });
 
 When("I click on tab for unpublished news", () => {
-	news.clickOnTabUnpublishedNews()
+	news.clickOnTabUnpublishedNews();
 });
 
 Then("I see the unpublished news {string}", (newsTitle) => {
-	news.seeNewsWhenNewsNotYetPublished(newsTitle)
+	news.seeNewsWhenNewsNotYetPublished(newsTitle);
 });
-
-


### PR DESCRIPTION
# Description
- Updated news features for the data-testids.
- Added address link in the news ck in the feature -> createReadDeleteSchoolNewsInAdvance.feature.
<!--
  This is a template to add as much information as possible to the pull request, to help reviewer and as a checklist for you. Points to remember are set in the comments, please read and keep them in mind:
    - Code should be self-explanatory and share your knowledge with others
    - Document code that is not self-explanatory
    - Think about bugs and keep security in mind
    - Write tests (Unit and Integration), also for error cases
    - Main logic should be hidden behind the api, never trust the client
    - Visible changes should be discussed with the UX-Team from the beginning of development; they also have to accept them at the end
    - Keep the changelog up-to-date
    - Leave the code cleaner than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Tickets or other pull requests
BC-11691
https://github.com/hpi-schul-cloud/nuxt-client/pull/4214
https://github.com/hpi-schul-cloud/schulcloud-server/pull/6284
<!-- related-prs-and-tickets-start -->
<!-- related-prs-and-tickets-end -->

## Screenshots of UI changes

<!--
  only needed for visual changes
  If visual changes exist, work together with UI/UX from beginning/ping UX with final PR
-->

## Approval for review

- [ ] DEV: If the API or client code was changed, all necessary code generation or synchronization steps were completed and tested.
- [ ] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

