### PR TITLE
BC-11858: Students no longer see Add External Person option in FAB speed dial

### DIFF
--- a/cypress/e2e/rooms/studentsInRooms/studentsAddStudentsFromOwnSchoolOnDBCAndBRB.feature
+++ b/cypress/e2e/rooms/studentsInRooms/studentsAddStudentsFromOwnSchoolOnDBCAndBRB.feature
@@ -68,7 +68,7 @@ Feature: Rooms - Students can only add students from their own classes to a room
         When I select the three dot menu action 'room-members'
         Then I see the page Edit participants of room '<room_name>'
         When I click on FAB to add participants
-        Then I see speed dial options 'select-from-directory, add-external-person'
+        Then I see speed dial options 'select-from-directory'
         When I click on button 'select-from-directory' from speed dial option
         Then I see modal Add participants
         Then I see school '<school_name>' in dropdown School
@@ -108,7 +108,7 @@ Feature: Rooms - Students can only add students from their own classes to a room
         When I select the three dot menu action 'room-members'
         Then I see the page Edit participants of room '<room_name>'
         When I click on FAB to add participants
-        Then I see speed dial options 'select-from-directory, add-external-person'
+        Then I see speed dial options 'select-from-directory'
         When I click on button 'select-from-directory' from speed dial option
         Then I see modal Add participants
         Then I see school '<school_name>' in dropdown School

--- a/cypress/e2e/rooms/studentsInRooms/studentsAddStudentsFromOwnSchoolOnDBCAndBRB.feature
+++ b/cypress/e2e/rooms/studentsInRooms/studentsAddStudentsFromOwnSchoolOnDBCAndBRB.feature
@@ -69,6 +69,7 @@ Feature: Rooms - Students can only add students from their own classes to a room
         Then I see the page Edit participants of room '<room_name>'
         When I click on FAB to add participants
         Then I see speed dial options 'select-from-directory'
+        Then I don't see speed dial options 'add-external-person'
         When I click on button 'select-from-directory' from speed dial option
         Then I see modal Add participants
         Then I see school '<school_name>' in dropdown School
@@ -109,6 +110,7 @@ Feature: Rooms - Students can only add students from their own classes to a room
         Then I see the page Edit participants of room '<room_name>'
         When I click on FAB to add participants
         Then I see speed dial options 'select-from-directory'
+        Then I don't see speed dial options 'add-external-person'
         When I click on button 'select-from-directory' from speed dial option
         Then I see modal Add participants
         Then I see school '<school_name>' in dropdown School

--- a/cypress/e2e/rooms/studentsInRooms/studentsAddStudentsFromOwnSchoolOnNBC.feature
+++ b/cypress/e2e/rooms/studentsInRooms/studentsAddStudentsFromOwnSchoolOnNBC.feature
@@ -68,7 +68,7 @@ Feature: Rooms - Students can only add students from their own classes to a room
         When I select the three dot menu action 'room-members'
         Then I see the page Edit participants of room '<room_name>'
         When I click on FAB to add participants
-        Then I see speed dial options 'select-from-directory, add-external-person'
+        Then I see speed dial options 'select-from-directory'
         When I click on button 'select-from-directory' from speed dial option
         Then I see modal Add participants
         Then I see school '<school_name>' in dropdown School
@@ -112,7 +112,7 @@ Feature: Rooms - Students can only add students from their own classes to a room
         When I select the three dot menu action 'room-members'
         Then I see the page Edit participants of room '<room_name>'
         When I click on FAB to add participants
-        Then I see speed dial options 'select-from-directory, add-external-person'
+        Then I see speed dial options 'select-from-directory'
         When I click on button 'select-from-directory' from speed dial option
         Then I see modal Add participants
         Then I see school '<school_name>' in dropdown School

--- a/cypress/e2e/rooms/studentsInRooms/studentsAddStudentsFromOwnSchoolOnNBC.feature
+++ b/cypress/e2e/rooms/studentsInRooms/studentsAddStudentsFromOwnSchoolOnNBC.feature
@@ -69,6 +69,7 @@ Feature: Rooms - Students can only add students from their own classes to a room
         Then I see the page Edit participants of room '<room_name>'
         When I click on FAB to add participants
         Then I see speed dial options 'select-from-directory'
+        Then I don't see speed dial options 'add-external-person'
         When I click on button 'select-from-directory' from speed dial option
         Then I see modal Add participants
         Then I see school '<school_name>' in dropdown School
@@ -113,6 +114,7 @@ Feature: Rooms - Students can only add students from their own classes to a room
         Then I see the page Edit participants of room '<room_name>'
         When I click on FAB to add participants
         Then I see speed dial options 'select-from-directory'
+        Then I don't see speed dial options 'add-external-person'
         When I click on button 'select-from-directory' from speed dial option
         Then I see modal Add participants
         Then I see school '<school_name>' in dropdown School

--- a/cypress/support/pages/rooms/pageRooms.js
+++ b/cypress/support/pages/rooms/pageRooms.js
@@ -834,5 +834,12 @@ class Rooms {
 			.find('[type="checkbox"]')
 			.should(linkExpirationAction === "check" ? "be.checked" : "not.be.checked");
 	}
+
+    doNotSeeSpeedDialOptions(options) {
+		const buttonName = options.split(/,|and/).map((option) => option.trim());
+		buttonName.forEach((buttonName) => {
+			cy.get(`[data-testid="fab-${buttonName}-icon-btn"]`).should("not.exist");
+		});
+	}
 }
 export default Rooms;

--- a/cypress/support/step_definition/rooms/commonRoomsSteps.spec.js
+++ b/cypress/support/step_definition/rooms/commonRoomsSteps.spec.js
@@ -22,3 +22,7 @@ When("I click on button {string} from speed dial option", (option) => {
 When("I see the checkbox Link Expiration as {string}", (linkExpirationAction) => {
 	rooms.verifyLinkExpirationInInvitationDialog(linkExpirationAction);
 });
+
+Then("I don't see speed dial options {string}", (options) => {
+	rooms.doNotSeeSpeedDialOptions(options);
+});


### PR DESCRIPTION
# Description

The E2E tests studentsAddStudentsFromOwnSchoolOnDBC/BRB and studentsAddStudentsFromOwnSchoolOnNBC are failing because the "Add External Person" option is no longer visible for students in the FAB speed dial menu.

**Affected Tests:**

- studentsAddStudentsFromOwnSchoolOnDBCAndBRB
- studentsAddStudentsFromOwnSchoolOnNBC

## Links to Tickets or other pull requests
[BC-11858](https://ticketsystem.dbildungscloud.de/browse/BC-11858)

## Screenshots of UI changes

<!--
  only needed for visual changes
  If visual changes exist, work together with UI/UX from beginning/ping UX with final PR
-->

## Approval for review

- [ ] DEV: If the API or client code was changed, all necessary code generation or synchronization steps were completed and tested.
- [ ] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

