### PR TITLE
BC-11359 Added multiple rooms selection to board import

### DIFF
--- a/cypress/e2e/room_board/share_import_board/shareAndImportMultiColumnRoomBoardInSameSchool.feature
+++ b/cypress/e2e/room_board/share_import_board/shareAndImportMultiColumnRoomBoardInSameSchool.feature
@@ -36,31 +36,42 @@ Feature: Room Board - Share multi-column room board in the rooms with teacher fr
         Then I copy the URL from the modal
         Then I see the success alert message
 
-        # pre-condition: second teacher is logged into the application, and a room exists
+        # pre-condition: second teacher is logged into the application, and two rooms exist
         Given I am logged in as a '<teacher2>' at '<namespace>'
-        Given a room named '<room_name_target>' exists
+        Given a room named '<room_name_target_1>' exists
+        Given a room named '<room_name_target_2>' exists
 
         # second teacher within the same school imports the multi-column board
         When I navigate to the shared URL
         Then I see the Dialog to import
         Then I see the title in the import modal
-        When I select the room from the room list in the modal
+        When I select two rooms '<room_name_target_1>' and '<room_name_target_2>' in the board import drop-down list
         When I click on the Continue button in the modal
         When I enter a new name for the imported board '<import_board_title>' in the modal
         When I click on the button Import in the import modal
-        Then I see the detail page of room '<room_name_target>'
+        Then I see the success alert message
+        Then I see room overview page
+        When I click on button Open to go to room '<room_name_target_1>' at position '0'
+        Then I see the detail page of room '<room_name_target_1>'
+        When I click on the button Open on multi-column board in the room detail page
+        Then I see the page board details
+        Then I see the chip Draft
+        When I go to rooms overview
+        When I click on button Open to go to room '<room_name_target_2>' at position '1'
+        Then I see the detail page of room '<room_name_target_2>'
         When I click on the button Open on multi-column board in the room detail page
         Then I see the page board details
         Then I see the chip Draft
 
         # post-condition: rooms created by both teachers are deleted
         Given I am logged in as a '<teacher2>' at '<namespace>'
-        Given the room '<room_name_target>' at position '0' is deleted
+        Given the room '<room_name_target_1>' at position '0' is deleted
+        Given the room '<room_name_target_2>' at position '0' is deleted
         Given I am logged in as a '<teacher1>' at '<namespace>'
         Given the room '<room_name_source>' at position '0' is deleted
 
         @school_api_test
         @staging_test
         Examples:
-            | teacher1     | teacher2     | namespace | room_name_source       | room_name_target       | board_title            | import_board_title            | copyright_data_protection | content_etherpad | content_whiteboard | external_tools_info | external_tools_protected_parameter_info |
-            | teacher1_brb | teacher2_brb | brb       | CypressAut Room Name-1 | CypressAut Room Name-2 | CypressAut Board Title | CypressAut Board Import Title | Copyright data protection | Content etherpad | Content whiteboard | External tools info | External tools protected parameter info |
+            | teacher1     | teacher2     | namespace | room_name_source       | room_name_target_1     | room_name_target_2     | board_title            | import_board_title            | copyright_data_protection | content_etherpad | content_whiteboard | external_tools_info | external_tools_protected_parameter_info |
+            | teacher1_brb | teacher2_brb | brb       | CypressAut Room Name-1 | CypressAut Room Name-2 | CypressAut Room Name-3 | CypressAut Board Title | CypressAut Board Import Title | Copyright data protection | Content etherpad | Content whiteboard | External tools info | External tools protected parameter info |

--- a/cypress/e2e/room_board/share_import_board/shareAndImportMultiColumnRoomBoardWithDifferentSchoolOnMainDev.feature
+++ b/cypress/e2e/room_board/share_import_board/shareAndImportMultiColumnRoomBoardWithDifferentSchoolOnMainDev.feature
@@ -39,16 +39,27 @@ Feature: Room Board - Share multi-column board in the rooms with the teacher fro
 
         # pre-condition: second teacher logged into the application, and a room exists
         Given I am logged in as a '<teacherExt_1>' at '<namespace>'
-        Given a room named '<room_name_target>' exists
+        Given a room named '<room_name_target_1>' exists
+        Given a room named '<room_name_target_2>' exists
 
         # second teacher from the second school can access the shared URL and import the multi-column board
         When I navigate to the shared URL
         Then I see the Dialog to import
         Then I see the title in the import modal
-        When I select the room from the room list in the modal
+        When I select two rooms '<room_name_target_1>' and '<room_name_target_2>' in the board import drop-down list
         When I click on the Continue button in the modal
         When I enter a new name for the imported board '<import_board_title>' in the modal
         When I click on the button Import in the import modal
+        Then I see the success alert message
+        Then I see room overview page
+        When I click on button Open to go to room '<room_name_target_1>' at position '0'
+        Then I see the detail page of room '<room_name_target_1>'
+        When I click on the button Open on multi-column board in the room detail page
+        Then I see the page board details
+        Then I see the chip Draft
+        When I go to rooms overview
+        When I click on button Open to go to room '<room_name_target_2>' at position '1'
+        Then I see the detail page of room '<room_name_target_2>'
         When I click on the button Open on multi-column board in the room detail page
         Then I see the page board details
         Then I see the chip Draft
@@ -78,10 +89,10 @@ Feature: Room Board - Share multi-column board in the rooms with the teacher fro
         Given I am logged in as a '<teacher1>' at '<namespace>'
         Given the room '<room_name_source>' at position '0' is deleted
         Given I am logged in as a '<teacherExt_1>' at '<namespace>'
-        Given the room '<room_name_target>' at position '0' is deleted
+        Given the room '<room_name_target_1>' at position '0' is deleted
+        Given the room '<room_name_target_2>' at position '0' is deleted
 
         @school_api_test
         Examples:
-            | teacher1     | teacherExt_1    | namespace | room_name_source    | room_name_target    | board_title    | import_board_title    | copyright_data_protection | content_etherpad | content_whiteboard | external_tools_info | external_tools_protected_parameter_info |
-            | teacher1_brb | teacherExt1_brb | brb       | Cypress Room Name-1 | Cypress Room Name-2 | Board Cy Title | Board Cy Import Title | Copyright data protection | Content etherpad | Content whiteboard | External tools info | External tools protected parameter info |
-
+            | teacher1     | teacherExt_1    | namespace | room_name_source    | room_name_target_1  | room_name_target_2  | board_title    | import_board_title    | copyright_data_protection | content_etherpad | content_whiteboard | external_tools_info | external_tools_protected_parameter_info |
+            | teacher1_brb | teacherExt1_brb | brb       | Cypress Room Name-1 | Cypress Room Name-2 | Cypress Room Name-3 | Board Cy Title | Board Cy Import Title | Copyright data protection | Content etherpad | Content whiteboard | External tools info | External tools protected parameter info |

--- a/cypress/e2e/room_board/share_import_board/shareAndImportMultiColumnRoomBoardWithDifferentSchoolOnStaging.feature
+++ b/cypress/e2e/room_board/share_import_board/shareAndImportMultiColumnRoomBoardWithDifferentSchoolOnStaging.feature
@@ -40,16 +40,27 @@ Feature: Room Board - Share multi-column board in the rooms with the teacher fro
 
         # pre-condition: second teacher logged into the application, and a room exists
         Given I am logged in as a '<teacherExt_1>' at '<namespace>'
-        Given a room named '<room_name_target>' exists
+        Given a room named '<room_name_target_1>' exists
+        Given a room named '<room_name_target_2>' exists
 
         # second teacher from the second school can access the shared URL and import the multi-column board
         When I navigate to the shared URL
         Then I see the Dialog to import
         Then I see the title in the import modal
-        When I select the room from the room list in the modal
+        When I select two rooms '<room_name_target_1>' and '<room_name_target_2>' in the board import drop-down list
         When I click on the Continue button in the modal
         When I enter a new name for the imported board '<import_board_title>' in the modal
         When I click on the button Import in the import modal
+        Then I see the success alert message
+        Then I see room overview page
+        When I click on button Open to go to room '<room_name_target_1>' at position '0'
+        Then I see the detail page of room '<room_name_target_1>'
+        When I click on the button Open on multi-column board in the room detail page
+        Then I see the page board details
+        Then I see the chip Draft
+        When I go to rooms overview
+        When I click on button Open to go to room '<room_name_target_2>' at position '1'
+        Then I see the detail page of room '<room_name_target_2>'
         When I click on the button Open on multi-column board in the room detail page
         Then I see the page board details
         Then I see the chip Draft
@@ -79,9 +90,10 @@ Feature: Room Board - Share multi-column board in the rooms with the teacher fro
         Given I am logged in as a '<teacher_1>' at '<namespace>'
         Given the room '<room_name_source>' at position '0' is deleted
         Given I am logged in as a '<teacherExt_1>' at '<namespace>'
-        Given the room '<room_name_target>' at position '0' is deleted
+        Given the room '<room_name_target_1>' at position '0' is deleted
+        Given the room '<room_name_target_2>' at position '0' is deleted
 
         @staging_test
         Examples:
-            | teacher_1    | teacherExt_1    | namespace | room_name_source       | room_name_target       | board_title            | import_board_title            | copyright_data_protection | content_etherpad | content_whiteboard | external_tools_info | external_tools_protected_parameter_info |
-            | teacher1_brb | teacherExt1_brb | brb       | CypressAut Room Name-1 | CypressAut Room Name-2 | CypressAut Board Title | CypressAut Board Import Title | Copyright data protection | Content etherpad | Content whiteboard | External tools info | External tools protected parameter info |
+            | teacher_1    | teacherExt_1    | namespace | room_name_source       | room_name_target_1     | room_name_target_2     | board_title            | import_board_title            | copyright_data_protection | content_etherpad | content_whiteboard | external_tools_info | external_tools_protected_parameter_info |
+            | teacher1_brb | teacherExt1_brb | brb       | CypressAut Room Name-1 | CypressAut Room Name-2 | CypressAut Room Name-3 | CypressAut Board Title | CypressAut Board Import Title | Copyright data protection | Content etherpad | Content whiteboard | External tools info | External tools protected parameter info |

--- a/cypress/support/pages/rooms/pageRooms.js
+++ b/cypress/support/pages/rooms/pageRooms.js
@@ -77,6 +77,10 @@ class Rooms {
 	static #dropdownOptions = `${Rooms.#dropdownListbox} [role="option"]`;
 	static #emptyStateInfoText = '[data-testid="empty-state-title"]';
 
+	seeRoomsOverviewPage() {
+		cy.url().should("include", "/rooms");
+	}
+
 	seeRoomMembersCountChipForRoom(roomName, roomMembersCount, position) {
 		cy.get(`[data-testid="board-grid-item-${position}"]`)
 			.should("be.visible")
@@ -196,7 +200,9 @@ class Rooms {
 				const index = testId.replace("room--title-", "");
 
 				// open and delete the room
-				cy.get(`[data-testid="room-open-button-${index}"]`).should("be.visible").click();
+				cy.get(`[data-testid="room-open-button-${index}"]`)
+					.should("be.visible")
+					.click();
 
 				cy.get(Rooms.#roomDetailFAB).should("be.visible").click();
 				cy.get(Rooms.#btnRoomDelete).should("be.visible").click();
@@ -422,13 +428,18 @@ class Rooms {
 					const menu = win.document.querySelector(`#${menuId}`);
 					expect(menu, `Menu #${menuId} should exist`).to.not.be.null;
 					const options = menu.querySelectorAll(Rooms.#threeDotMenuOptions);
-					expect(options.length, "Menu should have at least 1 option").to.be.at.least(1);
+					expect(
+						options.length,
+						"Menu should have at least 1 option"
+					).to.be.at.least(1);
 				});
 			});
 	}
 
 	clickOnKebabMenuAction(kebabMenuAction) {
-		cy.get(`[data-testid="kebab-menu-action-${kebabMenuAction.toLowerCase()}"]`).click();
+		cy.get(
+			`[data-testid="kebab-menu-action-${kebabMenuAction.toLowerCase()}"]`
+		).click();
 	}
 
 	seeConfirmationModalForRoomDeletion() {
@@ -479,7 +490,10 @@ class Rooms {
 	selectParticipantSchool() {
 		cy.get(Rooms.#addParticipantSchool).should("be.visible").click();
 		cy.get(Rooms.#dropdownListbox, { timeout: 10000 }).should("be.visible");
-		cy.get(Rooms.#dropdownOptions).should("have.length.greaterThan", 0).first().click();
+		cy.get(Rooms.#dropdownOptions)
+			.should("have.length.greaterThan", 0)
+			.first()
+			.click();
 		cy.get(Rooms.#dropdownListbox).should("not.exist");
 	}
 
@@ -520,7 +534,9 @@ class Rooms {
 			.within(() => {
 				cy.get(Rooms.#memberRowInRoomMembershipTable).click();
 			});
-		cy.get(`[data-testid="kebab-menu-action-${kebabMenuAction.toLowerCase()}"]`).click();
+		cy.get(
+			`[data-testid="kebab-menu-action-${kebabMenuAction.toLowerCase()}"]`
+		).click();
 	}
 
 	seeParticipantInList(participantName) {
@@ -587,7 +603,9 @@ class Rooms {
 	}
 
 	isParticipantNotVisible(participantName) {
-		cy.get(Rooms.#participantTable).contains("td", participantName).should("not.exist");
+		cy.get(Rooms.#participantTable)
+			.contains("td", participantName)
+			.should("not.exist");
 	}
 
 	isParticipantVisible(participantName) {
@@ -828,7 +846,7 @@ class Rooms {
 			.should(linkExpirationAction === "check" ? "be.checked" : "not.be.checked");
 	}
 
-    doNotSeeSpeedDialOptions(options) {
+	doNotSeeSpeedDialOptions(options) {
 		const buttonName = options.split(/,|and/).map((option) => option.trim());
 		buttonName.forEach((buttonName) => {
 			cy.get(`[data-testid="fab-${buttonName}-icon-btn"]`).should("not.exist");

--- a/cypress/support/pages/rooms/pageRooms.js
+++ b/cypress/support/pages/rooms/pageRooms.js
@@ -78,7 +78,7 @@ class Rooms {
 	static #emptyStateInfoText = '[data-testid="empty-state-title"]';
 
 	seeRoomsOverviewPage() {
-		cy.url().should("include", "/rooms");
+		cy.url().should("match", /\/rooms\/?$/);
 	}
 
 	seeRoomMembersCountChipForRoom(roomName, roomMembersCount, position) {

--- a/cypress/support/pages/rooms_board/pageRoomsBoard.js
+++ b/cypress/support/pages/rooms_board/pageRoomsBoard.js
@@ -20,7 +20,8 @@ class RoomBoards {
 	static #singleColumnBoardTileSelector = '[data-testid="board-grid-title-1"]';
 	static #elementSelectionDialog = '[data-testid="element-type-selection"]';
 	static #closeDialogButton = '[data-testid="dialog-close"]';
-	static #elementSelectionCancelButton = '[data-testid="element-type-selection-cancel"]';
+	static #elementSelectionCancelButton =
+		'[data-testid="element-type-selection-cancel"]';
 	static #videoConferenceTitleInput = '[data-testid="video-conference-element-title"]';
 	static #videoConferenceElement = '[data-testid="board-video-conference-element"]';
 	static #videoConferenceElementCreate =
@@ -35,7 +36,8 @@ class RoomBoards {
 	static #globalCommonThreeDotInCardElement = '[data-testid="board-menu-icon"]';
 	static #threeDotInBoardTitle = '[data-testid="board-menu-btn"]';
 	static #threeDotInLinkElement = '[data-testid="board-menu-button"]';
-	static #deleteOptionOnCardElementThreeDot = '[data-testid="kebab-menu-action-delete"]';
+	static #deleteOptionOnCardElementThreeDot =
+		'[data-testid="kebab-menu-action-delete"]';
 	static #threeDotButtonInCard = '[data-testid="card-menu-btn-0-0"]';
 	static #editOptionInCardThreeDot = '[data-testid="kebab-menu-action-edit"]';
 	static #importCardDialogTitle = '[data-testid="select-destination-modal-title"]';
@@ -82,11 +84,13 @@ class RoomBoards {
 	static #H5PPage = '[data-testid="skip-link"]';
 	static #titleAlert = '[role="alert"]';
 	static #fileTitleInCardInput = '[data-testid="file-name-input"]';
-	static #createDocumentButtonInFileFolder = '[data-testid="fab-button-create-document"]';
+	static #createDocumentButtonInFileFolder =
+		'[data-testid="fab-button-create-document"]';
 	static #dialogCreateDocumentInFileFolder = '[data-testid="collabora-file-dialog"]';
 	static #dialogCreateDocumentTitleInFileFolder =
 		'[data-testid="collabora-file-dialog-title"]';
-	static #dialogSelectDocumentTypeFileFolder = '[data-testid="collabora-file-form-type"]';
+	static #dialogSelectDocumentTypeFileFolder =
+		'[data-testid="collabora-file-form-type"]';
 	static #dialogFileNameFileFolder = '[data-testid="collabora-file-form-filename"]';
 	static #dialogCreateButton = '[data-testid="collabora-file-dialog-confirm"]';
 	static #boardContentElementBar = '[data-testid="content-element-bar-board"]';
@@ -114,7 +118,8 @@ class RoomBoards {
 	static #folderTitleInCardInput = '[data-testid="folder-title-text-field-in-card"]';
 	static #boardTitlePattern = '[data-testid^="board-title-"]';
 	static #parameterDisplayNameBettermarks = '[data-testid="parameter-display-name"]';
-	static #bettermarksToolDomainUrl = '[data-testid="board-external-tool-element-domain"]';
+	static #bettermarksToolDomainUrl =
+		'[data-testid="board-external-tool-element-domain"]';
 	static #body = "body";
 	static #duplicatedCardPosition = '[data-testid="board-card-0-1"]';
 	static #firstCardPositionInRoomBoard = '[data-testid="board-card-0-0"]';
@@ -130,7 +135,8 @@ class RoomBoards {
 	static #moveCardSelectRoom = '[data-testid="move-card-select-room"]';
 	static #moveCardSelectColumn = '[data-testid="move-card-select-column"]';
 	static #confirmButtonOnModal = '[data-testid="rename-folder-dialog-confirm"]';
-	static #confirmRenamingFileButtonOnModal = '[data-testid="rename-file-dialog-confirm"]';
+	static #confirmRenamingFileButtonOnModal =
+		'[data-testid="rename-file-dialog-confirm"]';
 	static #globalDialogConfirmButton = '[data-testid="import-modal-confirm"]';
 	static #confirmDialogConfirm = '[data-testid="confirm-dialog-confirm"]';
 	static #importCardDialogConfirm = '[data-testid="import-card-dialog-confirm"]';
@@ -148,7 +154,8 @@ class RoomBoards {
 	static #trashPageMenuButton = '[data-testid="folder-trash-menu"]';
 	static #permanentDeleteDialog = '[data-testid="purge-files-dialog"]';
 	static #permanentDeleteFileModalTitle = '[data-testid="purge-files-dialog-title"]';
-	static #permanentDeleteWarningCheckbox = '[data-testid="purge-files-dialog-checkbox"]';
+	static #permanentDeleteWarningCheckbox =
+		'[data-testid="purge-files-dialog-checkbox"]';
 	static #permanentDeleteConfirmButton = '[data-testid="purge-files-dialog-confirm"]';
 	static #importRoomsModalTitle = '[data-testid="import-dialog-title"]';
 	static #shareInfoCopyrightDataProtection =
@@ -161,6 +168,24 @@ class RoomBoards {
 	static #closeElementDetailViewButton = '[data-testid="close-detail-view-button"]';
 	static #externalToolsInBoard = '[data-testid^="board-external-tool-element-"]';
 	static #alertLinkButton = '[data-testid="alert-link"]';
+	static #checkboxImportRoomList = 'input[type="checkbox"]';
+
+	selectTwoRoomsForBoardImport(roomName1, roomName2) {
+		cy.get(
+			`${RoomBoards.#dialogTitle}, ${RoomBoards.#selectDestinationModalTitle}`
+		).should("exist");
+		cy.get(RoomBoards.#roomSelectionBoxModal).click();
+		// select first room
+		cy.contains('[role="option"]', roomName1)
+			.find(RoomBoards.#checkboxImportRoomList)
+			.check({ force: true });
+		// select second room
+		cy.contains('[role="option"]', roomName2)
+			.find(RoomBoards.#checkboxImportRoomList)
+			.check({ force: true });
+		// close the dropdown
+		cy.get(RoomBoards.#selectDestinationModalTitle).click();
+	}
 
 	clickAlertMessageLinkButton() {
 		cy.get(RoomBoards.#shareImportAlert).within(() => {
@@ -468,10 +493,12 @@ class RoomBoards {
 
 		// assert layout position: duplicated card is rendered below the original
 		cy.get(RoomBoards.#firstCardPositionInRoomBoard).then(($original) => {
-			const originalBottom = $original[0].getBoundingClientRect().bottom + window.scrollY;
+			const originalBottom =
+				$original[0].getBoundingClientRect().bottom + window.scrollY;
 
 			cy.get(RoomBoards.#duplicatedCardPosition).then(($duplicate) => {
-				const duplicateTop = $duplicate[0].getBoundingClientRect().top + window.scrollY;
+				const duplicateTop =
+					$duplicate[0].getBoundingClientRect().top + window.scrollY;
 
 				expect(duplicateTop).to.be.greaterThan(
 					originalBottom,
@@ -1016,7 +1043,9 @@ class RoomBoards {
 				expect(boardUrl).to.be.a("string").and.not.be.empty;
 				cy.wrap(boardUrl).as("copiedURL");
 				cy.window().then((win) => {
-					cy.stub(win.navigator.clipboard, "writeText").as("writeTextStub").resolves();
+					cy.stub(win.navigator.clipboard, "writeText")
+						.as("writeTextStub")
+						.resolves();
 				});
 				cy.get(RoomBoards.#copyLinkOption).click();
 				cy.get("@writeTextStub").should("be.calledOnce");
@@ -1283,7 +1312,9 @@ class RoomBoards {
 	}
 
 	seeFolderElementWithTitle(title) {
-		cy.get(RoomBoards.#folderElementSelector).should("exist").should("contain", title);
+		cy.get(RoomBoards.#folderElementSelector)
+			.should("exist")
+			.should("contain", title);
 	}
 
 	seeFolderElementWithSizeAndNumberOfFiles(folderDetails) {
@@ -1313,7 +1344,9 @@ class RoomBoards {
 	}
 
 	seeTrashInfoAlert(message) {
-		cy.get(RoomBoards.#trashInfoAlert).should("be.visible").and("contain.text", message);
+		cy.get(RoomBoards.#trashInfoAlert)
+			.should("be.visible")
+			.and("contain.text", message);
 	}
 
 	seeNoDataTable() {
@@ -1377,14 +1410,21 @@ class RoomBoards {
 			.map((opt) => opt.trim());
 		headerlabels.forEach((label) => {
 			cy.get(RoomBoards.#dataTable).within((element) => {
-				cy.get(element).find("th").contains("span", label).should("contain", label);
+				cy.get(element)
+					.find("th")
+					.contains("span", label)
+					.should("contain", label);
 			});
 		});
 	}
 
 	clickOnTableHeaderLink(label) {
 		cy.get(RoomBoards.#dataTable).within((element) => {
-			cy.get(element).find("th").contains("span", label).should("contain", label).click();
+			cy.get(element)
+				.find("th")
+				.contains("span", label)
+				.should("contain", label)
+				.click();
 		});
 	}
 
@@ -1398,11 +1438,15 @@ class RoomBoards {
 	}
 
 	checkCheckboxOfFile(fileName) {
-		cy.get(`[data-testid="select-checkbox-${fileName}"]`).find("div div input").check();
+		cy.get(`[data-testid="select-checkbox-${fileName}"]`)
+			.find("div div input")
+			.check();
 	}
 
 	uncheckCheckboxOfFile(fileName) {
-		cy.get(`[data-testid="select-checkbox-${fileName}"]`).find("div div input").uncheck();
+		cy.get(`[data-testid="select-checkbox-${fileName}"]`)
+			.find("div div input")
+			.uncheck();
 	}
 
 	seeFileCheckboxesAreChecked(files) {
@@ -1466,7 +1510,11 @@ class RoomBoards {
 	}
 
 	enterFolderNameInBoardCard(newName) {
-		cy.get(RoomBoards.#folderTitleInCardInput).find("input").eq(0).clear().type(newName);
+		cy.get(RoomBoards.#folderTitleInCardInput)
+			.find("input")
+			.eq(0)
+			.clear()
+			.type(newName);
 	}
 
 	clearFolderNameInCard() {

--- a/cypress/support/pages/rooms_board/pageRoomsBoard.js
+++ b/cypress/support/pages/rooms_board/pageRoomsBoard.js
@@ -169,20 +169,26 @@ class RoomBoards {
 	static #externalToolsInBoard = '[data-testid^="board-external-tool-element-"]';
 	static #alertLinkButton = '[data-testid="alert-link"]';
 	static #checkboxImportRoomList = 'input[type="checkbox"]';
+	static #listboxRoomsSelection = 'div[role="listbox"]';
 
 	selectTwoRoomsForBoardImport(roomName1, roomName2) {
 		cy.get(
 			`${RoomBoards.#dialogTitle}, ${RoomBoards.#selectDestinationModalTitle}`
 		).should("exist");
 		cy.get(RoomBoards.#roomSelectionBoxModal).click();
-		// select first room
-		cy.contains('[role="option"]', roomName1)
-			.find(RoomBoards.#checkboxImportRoomList)
-			.check({ force: true });
-		// select second room
-		cy.contains('[role="option"]', roomName2)
-			.find(RoomBoards.#checkboxImportRoomList)
-			.check({ force: true });
+		// wait for the listbox to be visible before interacting with it
+		cy.get(RoomBoards.#listboxRoomsSelection)
+			.should("be.visible")
+			.within(() => {
+				// select first room
+				cy.contains('[role="option"]', roomName1)
+					.find(RoomBoards.#checkboxImportRoomList)
+					.check({ force: true });
+				// select second room
+				cy.contains('[role="option"]', roomName2)
+					.find(RoomBoards.#checkboxImportRoomList)
+					.check({ force: true });
+			});
 		// close the dropdown
 		cy.get(RoomBoards.#selectDestinationModalTitle).click();
 	}

--- a/cypress/support/step_definition/rooms/roomsSteps.spec.js
+++ b/cypress/support/step_definition/rooms/roomsSteps.spec.js
@@ -3,6 +3,10 @@ import Rooms from "../../pages/rooms/pageRooms";
 
 const rooms = new Rooms();
 
+Then("I see room overview page", () => {
+	rooms.seeRoomsOverviewPage();
+});
+
 Then(
 	"I see room members count chip with count {string} for room {string} at position {string}",
 	(roomMembersCount, roomName, position) => {

--- a/cypress/support/step_definition/rooms_board/roomsBoardSteps.spec.js
+++ b/cypress/support/step_definition/rooms_board/roomsBoardSteps.spec.js
@@ -11,6 +11,13 @@ const rooms = new Rooms();
 const globalActions = new GlobalActions();
 const globalAssertions = new GlobalAssertions();
 
+When(
+	"I select two rooms {string} and {string} in the board import drop-down list",
+	(roomName1, roomName2) => {
+		roomBoards.selectTwoRoomsForBoardImport(roomName1, roomName2);
+	}
+);
+
 When("I click on the button Link in the success alert message", () => {
 	roomBoards.clickAlertMessageLinkButton();
 });


### PR DESCRIPTION
# Description
- Added new steps in the board share/import feature that can allow to select two targets rooms for importin importing the board to those rooms in one import operation.
https://github.com/hpi-schul-cloud/e2e-system-tests/pull/563#pullrequestreview-4573552719
<!--
  This is a template to add as much information as possible to the pull request, to help reviewer and as a checklist for you. Points to remember are set in the comments, please read and keep them in mind:
    - Code should be self-explanatory and share your knowledge with others
    - Document code that is not self-explanatory
    - Think about bugs and keep security in mind
    - Write tests (Unit and Integration), also for error cases
    - Main logic should be hidden behind the api, never trust the client
    - Visible changes should be discussed with the UX-Team from the beginning of development; they also have to accept them at the end
    - Keep the changelog up-to-date
    - Leave the code cleaner than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Tickets or other pull requests
BC-11359
https://github.com/hpi-schul-cloud/nuxt-client/pull/4287
<!-- related-prs-and-tickets-start -->
<!-- related-prs-and-tickets-end -->

## Screenshots of UI changes

<!--
  only needed for visual changes
  If visual changes exist, work together with UI/UX from beginning/ping UX with final PR
-->

## Approval for review

- [ ] DEV: If the API or client code was changed, all necessary code generation or synchronization steps were completed and tested.
- [ ] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

