### PR TITLE
BC-11802 Updated tests for external tool edit behaviour 

### DIFF
--- a/cypress/e2e/courses/shareCourseWithCtlTools.feature
+++ b/cypress/e2e/courses/shareCourseWithCtlTools.feature
@@ -81,8 +81,6 @@ Feature: Course - Teacher can share a course with CTL tools
         Then I see an external tool element with tool '<ctl_tool_scope_context>'
 
         # pre-condition: teacher adds a tool with optional protected parameter
-        When I click on three dot menu in the card
-        When I select the option Edit in three dot menu on the card
         When I click on icon Plus to add content into card
         When I select external tools from the element selection dialog box
         When I select the tool '<ctl_tool_optional_protected_param>' from available tools
@@ -92,8 +90,6 @@ Feature: Course - Teacher can share a course with CTL tools
         Then I see an external tool element with tool '<ctl_tool_optional_protected_param>'
 
         # pre-condition: teacher adds a tool with required parameter
-        When I click on three dot menu in the card
-        When I select the option Edit in three dot menu on the card
         When I click on icon Plus to add content into card
         When I select external tools from the element selection dialog box
         When I select the tool '<ctl_tool_protected_param>' from available tools

--- a/cypress/e2e/courses_board/addEditDeleteCtlToolInBoard.feature
+++ b/cypress/e2e/courses_board/addEditDeleteCtlToolInBoard.feature
@@ -66,8 +66,6 @@ Feature: Course Board  - To add, edit and delete a ctl tool in a board
         Then I see an external tool element with tool '<ctl_tool_1_new>'
 
         # teacher adds tool via tool link
-        When I click on three dot menu in the card
-        When I select the option Edit in three dot menu on the card
         When I click on icon Plus to add content into card
         When I select external tools from the element selection dialog box
         When I insert the external tool link '<ctl_tool_link>'
@@ -79,8 +77,6 @@ Feature: Course Board  - To add, edit and delete a ctl tool in a board
         Then I see an external tool element with tool '<ctl_tool_openstreetmap>'
 
         # teacher adds tool with a required custom parameter
-        When I click on three dot menu in the card
-        When I select the option Edit in three dot menu on the card
         When I click on icon Plus to add content into card
         When I select external tools from the element selection dialog box
         When I select the tool '<ctl_tool_required_param>' from available tools
@@ -94,8 +90,6 @@ Feature: Course Board  - To add, edit and delete a ctl tool in a board
         Then I see an external tool element with tool '<ctl_tool_required_param>'
 
         # teacher adds a tool with an optional custom parameter
-        When I click on three dot menu in the card
-        When I select the option Edit in three dot menu on the card
         When I click on icon Plus to add content into card
         When I select external tools from the element selection dialog box
         When I select the tool '<ctl_tool_optional_param>' from available tools
@@ -106,24 +100,18 @@ Feature: Course Board  - To add, edit and delete a ctl tool in a board
         Then I see an external tool element with tool '<ctl_tool_optional_param>'
 
         # teacher edits a tool
-        When I click on three dot menu in the card
-        When I select the option Edit in three dot menu on the card
         When I click on three dot menu of external tool element '<ctl_tool_optional_param>'
         When I click the edit button in three dot menu on the element
         Then I see tool '<ctl_tool_optional_param>' is selected
         Then I see custom parameter input field '<context_param_name>' contains '<param_value>'
         When I enter '<param_value_updated>' in optional custom parameter field '<context_param_name>'
         When I click on button Add in the modal to add an external tool
-        When I click on three dot menu in the card
-        When I select the option Edit in three dot menu on the card
         When I click on three dot menu of external tool element '<ctl_tool_optional_param>'
         When I click the edit button in three dot menu on the element
         Then I see custom parameter input field '<context_param_name>' contains '<param_value_updated>'
         When I click on button Add in the modal to add an external tool
 
         # teacher deletes tools from board
-        When I click on three dot menu in the card
-        When I select the option Edit in three dot menu on the card
         When I click on three dot menu of external tool element '<ctl_tool_optional_param>'
         When I click the delete button in three dot menu on the element
         When I click on the button Remove on the Modal

--- a/cypress/e2e/courses_board/contextRestrictionOfCtlToolsInBoard.feature
+++ b/cypress/e2e/courses_board/contextRestrictionOfCtlToolsInBoard.feature
@@ -55,8 +55,6 @@ Feature: Course Board - Restrict CTL tools to context board-element
         Then I see an external tool element with tool '<ctl_tool_restriction_board_element>'
 
         # teacher adds a tool with all context restrictions
-        When I click on three dot menu in the card
-        When I select the option Edit in three dot menu on the card
         When I click on icon Plus to add content into card
         When I select external tools from the element selection dialog box
         When I select the tool '<ctl_tool_restriction_all>' from available tools
@@ -65,8 +63,6 @@ Feature: Course Board - Restrict CTL tools to context board-element
         Then I see an external tool element with tool '<ctl_tool_restriction_all>'
 
         # teacher adds a tool without any context restriction
-        When I click on three dot menu in the card
-        When I select the option Edit in three dot menu on the card
         When I click on icon Plus to add content into card
         When I select external tools from the element selection dialog box
         When I select the tool '<ctl_tool_1>' from available tools
@@ -75,8 +71,6 @@ Feature: Course Board - Restrict CTL tools to context board-element
         Then I see an external tool element with tool '<ctl_tool_1>'
 
         # teacher tries to add a preferred tool with context restriction course
-        When I click on three dot menu in the card
-        When I select the option Edit in three dot menu on the card
         When I click on icon Plus to add content into card
         Then I do not see preferred tool '<ctl_tool_preferred_restriction_course>' in the menu
 

--- a/cypress/e2e/courses_board/copyCourseWithCtlToolsInBoard.feature
+++ b/cypress/e2e/courses_board/copyCourseWithCtlToolsInBoard.feature
@@ -60,8 +60,6 @@ Feature: Course Board - Copy course with a board which has CTL tools
         Then I see an external tool element with tool '<ctl_tool_scope_context>'
 
         # pre-condition: teacher adds a tool with optional protected parameter
-        When I click on three dot menu in the card
-        When I select the option Edit in three dot menu on the card
         When I click on icon Plus to add content into card
         When I select external tools from the element selection dialog box
         When I select the tool '<ctl_tool_optional_protected_param>' from available tools
@@ -71,8 +69,6 @@ Feature: Course Board - Copy course with a board which has CTL tools
         Then I see an external tool element with tool '<ctl_tool_optional_protected_param>'
 
         # pre-condition: teacher adds a tool with required parameter
-        When I click on three dot menu in the card
-        When I select the option Edit in three dot menu on the card
         When I click on icon Plus to add content into card
         When I select external tools from the element selection dialog box
         When I select the tool '<ctl_tool_protected_param>' from available tools
@@ -152,8 +148,6 @@ Feature: Course Board - Copy course with a board which has CTL tools
         When I select '<param_required_protected_value>' in required protected custom parameter selection
         When I click on button Add in the modal to add an external tool
         Then I see external tool element with tool '<ctl_tool_scope_context>' is not marked as incomplete
-        When I click on three dot menu in the card
-        When I select the option Edit in three dot menu on the card
         When I click on three dot menu of external tool element '<ctl_tool_optional_protected_param>'
         When I click the edit button in three dot menu on the element
         Then I see tool '<ctl_tool_optional_protected_param>' is selected

--- a/cypress/support/pages/courses_board/pageCoursesBoard.js
+++ b/cypress/support/pages/courses_board/pageCoursesBoard.js
@@ -386,8 +386,8 @@ class Board {
 
 	launchTool(toolName, toolURL) {
 		const launchedTool = { toolName: toolName, isLaunched: false };
-		// click outside to ensure added link element url is clickable and not in edit mode
-		cy.get("body").click("topRight");
+		// exit card edit mode so the external tool link is clickable
+		this.clickOutsideTheCardToSaveTheCard();
 		cy.window().then((win) => {
 			cy.stub(win, "open")
 				.as("openStub")

--- a/cypress/support/pages/courses_board/pageCoursesBoard.js
+++ b/cypress/support/pages/courses_board/pageCoursesBoard.js
@@ -386,6 +386,8 @@ class Board {
 
 	launchTool(toolName, toolURL) {
 		const launchedTool = { toolName: toolName, isLaunched: false };
+		// click outside to ensure added link element url is clickable and not in edit mode
+		cy.get("body").click("topRight");
 		cy.window().then((win) => {
 			cy.stub(win, "open")
 				.as("openStub")


### PR DESCRIPTION
# Description
- New change in BC-11802, now after adding an external tool, the card stays in the edit mode instead of direct saved.
- Adpated card edit's steps where its not needed anymore once new ext tool has added.
<!--
  This is a template to add as much information as possible to the pull request, to help reviewer and as a checklist for you. Points to remember are set in the comments, please read and keep them in mind:
    - Code should be self-explanatory and share your knowledge with others
    - Document code that is not self-explanatory
    - Think about bugs and keep security in mind
    - Write tests (Unit and Integration), also for error cases
    - Main logic should be hidden behind the api, never trust the client
    - Visible changes should be discussed with the UX-Team from the beginning of development; they also have to accept them at the end
    - Keep the changelog up-to-date
    - Leave the code cleaner than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Tickets or other pull requests
BC-11802
https://github.com/hpi-schul-cloud/nuxt-client/pull/4290
<!-- related-prs-and-tickets-start -->
<!-- related-prs-and-tickets-end -->

## Screenshots of UI changes

<!--
  only needed for visual changes
  If visual changes exist, work together with UI/UX from beginning/ping UX with final PR
-->

## Approval for review

- [ ] DEV: If the API or client code was changed, all necessary code generation or synchronization steps were completed and tested.
- [ ] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

