### PR TITLE
BC-12084 - fix mapping of subdomain part to instance-name

### DIFF
--- a/scripts/runSchoolApi.js
+++ b/scripts/runSchoolApi.js
@@ -6,8 +6,8 @@ const path = "/admin/api/v1";
 const endPointSchools = "/admin/schools";
 const endPointUsers = "/admin/users";
 const federalStateNames = {
-	nbc: "Niedersachsen",
-	brb: "Brandenburg",
+	niedersachsen: "Niedersachsen",
+	brandenburg: "Brandenburg",
 };
 const users = {
 	admin: "administrator",


### PR DESCRIPTION
# Description
Fix mapping of subdomain part
- original map having keys nbc and brb
- new map having keys niedersachsen and brandenburg

as new urls are:
```
<branch>.brandenburg.schulcloud-verbund.org
<branch>.niedersachsen.schulcloud-verbund.org
<branch>.thueringen.schulcloud-verbund.org
```

## Links to Tickets or other pull requests
BC-12084

## Approval for review

- [ ] DEV: If the API or client code was changed, all necessary code generation or synchronization steps were completed and tested.
- [ ] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

